### PR TITLE
アプリの説明文を追加

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -13,6 +13,12 @@
  *= require_tree .
  *= require_self
  */
+@import url('https://fonts.googleapis.com/css2?family=Playwrite+NO:wght@100..400&display=swap');
+
 body {
-  background-color: #FEEABC; /* 任意の背景色を指定 */
+  background-color: #FEEABC; /* アプリケーションの背景色 */
+}
+
+h1.top-page-title {
+  font-family: "Playwrite NO", cursive;
 }

--- a/app/views/static_pages/top.html.erb
+++ b/app/views/static_pages/top.html.erb
@@ -1,12 +1,30 @@
 <%= render partial: "layouts/navbar" %>
+
 <div class="px-5 pt-5 my-5 text-center">
-<div class="row justify-content-center mt-5">
-  <div class="container">
-    <h1 class="display-1 fw-bold text-body-emphasis">Menu Maker</h1>
-  </div>
-  <div class="container">
-    <div class="col-lg-6 mx-auto">
-      <p class="lead mb-4">アプリの説明</p>
+  <div class="row justify-content-center mt-5">
+    <h1 class="display-1 fw-bold text-body-emphasis top-page-title">Menu Maker</h1>
+    <div class="h3 mt-3">
+      お気に入りのレシピで、あなた専用のメニュー表を作成しよう！
+    </div>
+
+    <div class="container-fluid mt-5">
+      <div class="h2 text-center"><ins><em>Menu Makerとは？</em></ins></div>
+      <p class="h5 mt-3">
+        <br>このアプリでは、クックパッドでレシピを検索し、お気に入りのレシピを簡単に保存することができます。
+        <br>保存したレシピから、あなたの好みに合わせたメニュー表を自由に作成可能です。
+        <br>レシピのURLを入力するだけで自動保存ができる他、手動でレシピ情報を入力することもできます。
+      </p>
+    </div>
+
+    <div class="container border border-dark rounded col-lg-9 mt-3 mx-auto text-start">
+      <h3 class="my-4">〜 使い方 〜</h3>
+      <ol class="lead">
+        <li>&nbsp;&nbsp;アカウントを作成してログインします。</li>
+        <li>「レシピ検索」ページのリンクから、クックパッドでレシピを検索します。</li>
+        <li>「レシピ保存」ページで保存方法（URL or 手動）を選択し、レシピを保存します。</li>
+        <li>「レシピ一覧」ページから、保存したレシピをメニュー表候補へ追加します。</li>
+        <li>「メニュー作成」ページで、4.で追加したメニュー表候補の中からレシピを選んで、メニュー表を作成します。</li>
+      </ol>
     </div>
   </div>
 </div>

--- a/config/database.yml
+++ b/config/database.yml
@@ -60,6 +60,7 @@ test:
   <<: *default
   database: menu_maker_test
   host: db
+  port: 5432
   username: postgres
   password: password
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,0 +1,17 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema[7.1].define(version: 0) do
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "plpgsql"
+
+end

--- a/spec/requests/static_pages_spec.rb
+++ b/spec/requests/static_pages_spec.rb
@@ -1,7 +1,15 @@
 require 'rails_helper'
 
 RSpec.describe "StaticPages", type: :request do
-  describe "GET /index" do
-    pending "add some examples (or delete) #{__FILE__}"
+  describe "GET /top" do
+    it "renders the top page" do
+      get root_path # root_pathはroot 'static_pages#top'によって生成されたヘルパーメソッドです
+      expect(response).to have_http_status(200)
+    end
+
+    it "includes 'Menu Maker' in the body" do
+      get root_path
+      expect(response.body).to include("Menu Maker") # トップページに表示されるタイトルなどの内容を検証する例
+    end
   end
 end


### PR DESCRIPTION
fix #71 
# 概要
トップページにリンク、説明文を追加
## 内容
- トップページのタイトル下部にアプリの説明と簡単な使用方法を加えました。
- Google Fontsを導入し、タイトルのフォントを変更しました。
- ナビゲーションバーに「レシピ検索」「レシピ保存」「レシピ一覧」「メニュー作成」のリンクがあることを確認しました。
- spec/requests/static_pages_spec.rbにトップページへのアクセスに関するテストを記述し、実施しました。

その他、database.ymlを一部修正しました。