### PR TITLE
パスワード再設定申請のページを作成

### DIFF
--- a/app/controllers/password_resets_controller.rb
+++ b/app/controllers/password_resets_controller.rb
@@ -1,0 +1,11 @@
+class PasswordResetsController < ApplicationController
+  skip_before_action :require_login
+
+  def nes; end
+
+  def edit; end
+
+  def create; end
+
+  def update; end
+end

--- a/app/views/password_resets/create.html.erb
+++ b/app/views/password_resets/create.html.erb
@@ -1,0 +1,2 @@
+<h1>PasswordResets#create</h1>
+<p>Find me in app/views/password_resets/create.html.erb</p>

--- a/app/views/password_resets/edit.html.erb
+++ b/app/views/password_resets/edit.html.erb
@@ -1,0 +1,2 @@
+<h1>PasswordResets#edit</h1>
+<p>Find me in app/views/password_resets/edit.html.erb</p>

--- a/app/views/password_resets/new.html.erb
+++ b/app/views/password_resets/new.html.erb
@@ -1,0 +1,26 @@
+<% content_for(:title, t('.title')) %>
+<div class="container">
+  <div class="col d-flex justify-content-end align-items-center">
+    <span class="d-inline-block my-3">
+      <%= link_to t('.to_top_page'), root_path, class: "custom-link" %>
+    </span>
+  </div>
+  <h1 class="text-center mt-3"><%= t('.title') %></h1>
+  <div class="card mt-5 custom-card-width mx-auto">
+    <div class="container py-2 my-5">
+      <div class="row justify-content-center">
+        <div class="col-md-8">
+          <%= form_with url: password_resets_path, local: true, method: :post do |f| %>
+            <div class="mb-5">
+              <%= f.label :email, class: "form-label" %>
+              <%= f.email_field :email, class: "form-control" %>
+            </div>
+            <div class="d-grid gap-2 col-6 mx-auto">
+              <%= f.submit t('.reset_password'), class: "btn btn-primary" %>
+            </div>
+          <% end %>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/password_resets/update.html.erb
+++ b/app/views/password_resets/update.html.erb
@@ -1,0 +1,2 @@
+<h1>PasswordResets#update</h1>
+<p>Find me in app/views/password_resets/update.html.erb</p>

--- a/app/views/user_sessions/new.html.erb
+++ b/app/views/user_sessions/new.html.erb
@@ -31,7 +31,7 @@
     <div class="row">
       <div class="col"></div>
       <div class="col-12 col-md-6 text-start mb-2">
-        <%= link_to t('.password_forget'), "#", class: "custom-link px-5" %>
+        <%= link_to t('.password_forget'), new_password_reset_path, class: "custom-link px-5" %>
       </div>
       <div class="w-100"></div>
       <div class="col"></div>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -41,3 +41,8 @@ ja:
       failure: ログインに失敗しました
     destroy:
       success: ログアウトしました
+  password_resets:
+    new:
+      to_top_page: トップページへ
+      title: パスワード再設定申請
+      reset_password: 申請する

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,7 @@ Rails.application.routes.draw do
   get 'login', to: 'user_sessions#new'
   post 'login', to: 'user_sessions#create'
   delete 'logout', to: 'user_sessions#destroy'
+  resources :password_resets, only: %i[new create edit update]
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.


### PR DESCRIPTION
fix #35 
# 概要
パスワード再設定申請ページ作成
## 内容
- パスワード再設定の申請用ページを作成しました。
- ページにアクセスできるよう、コントローラー、ルーティングの設定を行いました。
- ja.ymlファイルを更新し、i18n対応済み。