### PR TITLE
パスワードリセット機能のテストコードを作成

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -12,7 +12,7 @@ jobs:
 
     services:
       db:
-        image: postgres
+        image: postgres:latest  # 最新バージョンのPostgreSQLイメージを使用
         env:
           POSTGRES_DB: menu_maker_test
           POSTGRES_USER: postgres
@@ -23,27 +23,30 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.3.2
+          ruby-version: 3.3.2  # 使用するRubyのバージョンを指定
+          bundler-cache: true  # バンドラのキャッシュを有効にして、依存関係のインストールを高速化
 
       - name: Install dependencies
         run: |
-          gem install bundler --no-document
-          bundle config path vendor/bundle
+          bundle config set --local without 'development'
           bundle install --jobs 4 --retry 3
 
       - name: Setup database
+        env:
+          RAILS_ENV: test
         run: |
-          bundle exec rails db:create db:schema:load RAILS_ENV=test
+          bundle exec rails db:create db:schema:load
 
       - name: Run RSpec
         run: |
-          bundle exec rspec spec
+          bundle exec rspec
 
       - name: Show test results
+        if: success() || failure()  # テスト結果を表示するステップを成功/失敗にかかわらず実行
         run: |
           echo "RSpec tests completed successfully"

--- a/Gemfile
+++ b/Gemfile
@@ -58,6 +58,7 @@ group :development, :test do
   gem 'factory_bot_rails'
   gem 'spring-commands-rspec'
   gem 'faker', '~> 3.4', '>= 3.4.1', require: false
+  gem 'pry-byebug'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -85,6 +85,7 @@ GEM
     bootsnap (1.18.3)
       msgpack (~> 1.2)
     builder (3.3.0)
+    byebug (11.1.3)
     capybara (3.40.0)
       addressable
       matrix
@@ -95,6 +96,7 @@ GEM
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
     childprocess (5.0.0)
+    coderay (1.1.3)
     concurrent-ruby (1.3.3)
     config (5.5.1)
       deep_merge (~> 1.2, >= 1.2.1)
@@ -160,6 +162,7 @@ GEM
       net-smtp
     marcel (1.0.4)
     matrix (0.4.2)
+    method_source (1.1.0)
     mini_mime (1.1.5)
     minitest (5.24.0)
     msgpack (1.7.2)
@@ -202,6 +205,12 @@ GEM
       ast (~> 2.4.1)
       racc
     pg (1.5.6)
+    pry (0.14.2)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    pry-byebug (3.10.1)
+      byebug (~> 11.0)
+      pry (>= 0.13, < 0.15)
     psych (5.1.2)
       stringio
     public_suffix (6.0.0)
@@ -372,6 +381,7 @@ DEPENDENCIES
   jsbundling-rails
   letter_opener_web (~> 3.0)
   pg (~> 1.1)
+  pry-byebug
   puma (>= 5.0)
   rails (~> 7.1.3, >= 7.1.3.4)
   rails-i18n (~> 7.0.0)

--- a/app/controllers/password_resets_controller.rb
+++ b/app/controllers/password_resets_controller.rb
@@ -14,8 +14,7 @@ class PasswordResetsController < ApplicationController
     @user&.deliver_reset_password_instructions!
     # 「存在しないメールアドレスです」という旨の文言を表示すると、逆に存在するメールアドレスを特定されてしまうため、
     # あえて成功時のメッセージを送信させている
-    flash.now[:success] = t('.success')
-    redirect_to login_path
+    redirect_to login_path, success: t('.success')
   end
 
   def update

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -9,7 +9,7 @@ class UserMailer < ApplicationMailer
     @url  = edit_password_reset_url(@user.reset_password_token)
     mail(
       to: user.email,
-      subject: t('defaults.password_reset')
+      subject: t('.password_reset')
     )
   end
 end

--- a/app/views/password_resets/new.html.erb
+++ b/app/views/password_resets/new.html.erb
@@ -13,7 +13,7 @@
           <%= form_with url: password_resets_path, local: true, method: :post do |f| %>
             <div class="mb-5">
               <%= f.label :email, class: "form-label" %>
-              <%= f.email_field :email, class: "form-control" %>
+              <%= f.email_field :email, class: "form-control", required: true %>
             </div>
             <div class="d-grid gap-2 col-6 mx-auto">
               <%= f.submit t('.reset_password'), class: "btn btn-primary" %>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -41,9 +41,9 @@ ja:
       failure: ログインに失敗しました
     destroy:
       success: ログアウトしました
-  password_resets:
-    defaults:
+  user_mailer:
       password_reset: パスワードの再設定
+  password_resets:
     new:
       to_top_page: トップページへ
       title: パスワード再設定申請

--- a/spec/mailers/previews/user_mailer_preview.rb
+++ b/spec/mailers/previews/user_mailer_preview.rb
@@ -1,7 +1,0 @@
-# Preview all emails at http://localhost:3000/rails/mailers/user_mailer_mailer
-class UserMailerPreview < ActionMailer::Preview
-  # Preview this email at http://localhost:3000/rails/mailers/user_mailer_mailer/reset_password_email
-  def reset_password_email
-    UserMailer.reset_password_email
-  end
-end

--- a/spec/system/passeord_reset_spec.rb
+++ b/spec/system/passeord_reset_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+RSpec.describe 'パスワードリセット', type: :system do
+  let(:user) { create :user }
+
+  describe 'パスワード再設定メール送信' do
+    before do
+      visit new_password_reset_path
+      fill_in 'email', with: user.email
+      click_button '申請する'
+    end
+
+    it 'メール送信後のメッセージを確認' do
+      expect(page).to have_content('パスワード再設定メールを送信しました')
+    end
+  end
+end


### PR DESCRIPTION
fix #58 
# 概要
パスワードリセット機能のテストコード作成
## 内容
- パスワードリセット機能に関するテストコードを作成しました。
- .github/workflows/rspec.ymlの内容を修正しました。
- gem 'pry-byebug'を導入しました。
- パスワード再設定のメール送信時にフラッシュメッセージが表示されない問題を修正しました。
- パスワード性設定メールのタイトルが表示されない問題を修正しました。