### PR TITLE
ユーザー名編集ページを作成

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -33,7 +33,7 @@ header {
 .custom-link {
   color: #4C4C4C !important;
   text-decoration: none; /* アンダーラインを消す場合 */
-  font-size: 25px;
+  font-size: 20px;
 }
 .custom-link:hover {
   color: #61C359 !important; /* ホバー時に色を変える場合 */
@@ -58,9 +58,9 @@ footer {
 .btn-primary {
   background-color: #61C359; /* ボタンの色　*/
   border: none; /* ボーダーを消す　*/
-  letter-spacing: 25px; /* 文字の間隔　*/
+  letter-spacing: 10px; /* 文字の間隔　*/
   font-size: 25px; /* 文字サイズ　*/
-  text-indent: 25px;
+  text-indent: 10px;
 }
 .btn-primary:hover {
   background-color: #50a149 ; /* ホバー時の色 */
@@ -73,9 +73,9 @@ footer {
 .btn-secondary {
   background-color: #F78700; /* ボタンの色　*/
   border: none; /* ボーダーを消す　*/
-  letter-spacing: 25px; /* 文字の間隔　*/
+  letter-spacing: 10px; /* 文字の間隔　*/
   font-size: 25px; /* 文字サイズ　*/
-  text-indent: 25px;
+  text-indent: 10px;
 }
 .btn-secondary:hover {
   background-color: #d07301 ; /* ホバー時の色 */

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -1,0 +1,14 @@
+class ProfilesController < ApplicationController
+  before_action :require_login
+  before_action :set_user, only: %i[show edit_username]
+
+  def show; end
+
+  def edit_username; end
+
+  private
+
+  def set_user
+    @user = User.find(current_user.id)
+  end
+end

--- a/app/views/password_resets/edit.html.erb
+++ b/app/views/password_resets/edit.html.erb
@@ -8,7 +8,7 @@
         <%= form_with model: @user, url: password_reset_path(@token), method: :patch do |f| %>
           <div class="mb-3">
             <%= f.label :email, class: "form-label" %><br>
-            <%= @user.email %>
+            <%= f.email_field :email, class: 'form-control', value: @user.email, readonly: true %>
           </div>
           <div class="mb-3">
             <%= f.label :password, class: "form-label" %>

--- a/app/views/password_resets/new.html.erb
+++ b/app/views/password_resets/new.html.erb
@@ -6,7 +6,7 @@
     </span>
   </div>
   <h1 class="text-center mt-3"><%= t('.title') %></h1>
-  <div class="card mt-5 custom-card-width mx-auto">
+  <div class="card my-5 custom-card-width mx-auto">
     <div class="container py-2 my-5">
       <div class="row justify-content-center">
         <div class="col-md-8">

--- a/app/views/profiles/edit_username.html.erb
+++ b/app/views/profiles/edit_username.html.erb
@@ -1,0 +1,30 @@
+<% content_for(:title, t('.title')) %>
+<div class="container">
+  <div class="col d-flex justify-content-end align-items-center">
+    <span class="d-inline-block my-3">
+      <%= link_to t('.to_top_page'), root_path, class: "custom-link" %>
+    </span>
+  </div>
+  <h1 class="text-center mt-3"><%= t('.title') %></h1>
+  <%= form_with(model: @user, url: profile_path, local: true) do |f| %>
+  <div class="card mt-5 custom-card-width mx-auto">
+    <div class="container py-2 my-5">
+      <div class="row justify-content-center">
+        <div class="col-md-8">
+          <div class="mb-3">
+            <%= f.label :current_name, class: 'form-label' %>
+            <%= f.text_field :current_name, class: 'form-control', value: @user.name, readonly: true %>
+          </div>
+          <div class="mb-3">
+            <%= f.label :new_name, class: "form-label" %>
+            <%= f.text_field :new_name, class: "form-control" %>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="d-grid gap-2 col-4 mx-auto my-5">
+    <%= f.submit t('.update'), class: "btn btn-primary" %>
+  </div>
+  <% end %>
+</div>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -1,0 +1,47 @@
+<% content_for(:title, t('.title')) %>
+<div class="container">
+  <div class="col d-flex justify-content-end align-items-center">
+    <span class="d-inline-block my-3">
+      <%= link_to t('.to_top_page'), root_path, class: "custom-link" %>
+    </span>
+  </div>
+  <h1 class="text-center mt-3"><%= t('.title') %></h1>
+  <div class="card mt-5 custom-card-width mx-auto">
+    <div class="container py-2 mt-5">
+      <div class="row justify-content-center">
+        <div class="col-md-8">
+        <%= form_with(model: @user, url: profile_path, local: true) do |f| %>
+          <div class="mb-3">
+            <%= f.label :name, class: 'form-label' %>
+            <div class="row">
+              <div class="col-9">
+                <%= f.text_field :name, class: 'form-control', value: @user.name, readonly: true %>
+              </div>
+              <div class="d-grid gap-2 col-3 mx-auto">
+                <%= link_to t('.edit'), edit_username_profile_path, class: 'btn btn-primary text-center', style: "letter-spacing: 5px; font-size: inherit; text-indent: initial;" %>
+              </div>
+            </div>
+          </div>
+          <div class="mb-5">
+            <%= f.label :email, class: 'form-label' %>
+            <div class="row">
+              <div class="col-9">
+                <%= f.email_field :email, class: 'form-control', value: @user.email, readonly: true %>
+              </div>
+              <div class="d-grid gap-2 col-3 mx-auto">
+                <%= link_to t('.edit'), "#", class: 'btn btn-primary', style: "letter-spacing: 5px; font-size: inherit; text-indent: initial;" %>
+              </div>
+            </div>
+          </div>
+        <% end %>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="row mb-5">
+    <div class="col-7"></div>
+    <div class="col-5 text-start">
+      <%= link_to t('.password_change'), "#", class: 'btn btn-primary mt-3', style: "letter-spacing: 5px; font-size: inherit; text-indent: initial;" %>
+    </div>
+  </div>
+</div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -14,7 +14,7 @@
       <!-- 右側のリンク -->
       <div class="col d-flex justify-content-end align-items-center">
         <span class="d-inline-block me-5">
-          <%= link_to t('header.my_page'), "#", class: "custom-link" %>
+          <%= link_to t('header.my_page'), profile_path, class: "custom-link" %>
         </span>
         <span class="d-inline-block me-4">
         <%= link_to t('header.logout'), logout_path, class: "custom-link", data: { turbo_method: :delete } %>

--- a/app/views/user_sessions/new.html.erb
+++ b/app/views/user_sessions/new.html.erb
@@ -29,13 +29,13 @@
   </div>
   <div class="container-fluid mt-5">
     <div class="row">
-      <div class="col"></div>
-      <div class="col-12 col-md-6 text-start mb-2">
+      <div class="col-5"></div>
+      <div class="col-7 text-start mb-2">
         <%= link_to t('.password_forget'), new_password_reset_path, class: "custom-link px-5" %>
       </div>
       <div class="w-100"></div>
-      <div class="col"></div>
-      <div class="col-12 col-md-6 text-start">
+      <div class="col-5"></div>
+      <div class="col-7 text-start">
         <%= link_to t('.to_register_page'), new_user_path, class: "custom-link px-5" %>
       </div>
     </div>

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -8,3 +8,5 @@ ja:
         email: メールアドレス
         password: パスワード
         password_confirmation: パスワード（確認用）
+        current_name: 現在のユーザー名
+        new_name: 新しいユーザー名

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -55,3 +55,14 @@ ja:
     update:
       success: パスワードを変更しました
       failure: パスワードの変更に失敗しました
+  profiles:
+    show:
+      to_top_page: トップページへ
+      title: マイページ
+      edit: 編集
+      password_change: パスワード変更
+    edit_username:
+      to_top_page: トップページへ
+      title: ユーザー名編集
+      update: 変更する
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,16 @@ Rails.application.routes.draw do
   
   root 'static_pages#top'
   resources :users, only: %i[new create]
+  resource :profile, only: %i[show edit update] do
+    collection do
+      get 'edit_username'
+      patch 'update_username'
+      get 'edit_email'
+      patch 'update_email'
+      get 'edit_password'
+      patch 'update_password'
+    end
+  end
   get 'login', to: 'user_sessions#new'
   post 'login', to: 'user_sessions#create'
   delete 'logout', to: 'user_sessions#destroy'


### PR DESCRIPTION
fix #13 
# 概要
ユーザー名変更ページ作成
## 内容
- app/views/profiles/show.html.erbにマイページのレイアウトを作成しました。
- app/views/profiles/edit_username.html.erbにユーザー名変更ページのレイアウトを作成しました。
- ルーティング、コントローラーについて、マイページ、ユーザー名変更ページにアクセスできるよう設定しました。
- パスワード再設定ページ、ログインページのビューを一部修正しました。
- ボタンのcssの設定を一部修正しました。