### PR TITLE
メールアドレス変更ページを作成

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -39,6 +39,7 @@ jobs:
       - name: Setup database
         env:
           RAILS_ENV: test
+          DB_HOST: localhost
         run: |
           bundle exec rails db:create db:schema:load
 

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -1,6 +1,6 @@
 class ProfilesController < ApplicationController
   before_action :require_login
-  before_action :set_user, only: %i[show edit_username update_username]
+  before_action :set_user, only: %i[show edit_username update_username edit_email]
 
   def show; end
 
@@ -14,6 +14,8 @@ class ProfilesController < ApplicationController
       render :edit_username, status: :unprocessable_entity
     end
   end
+
+  def edit_email; end
 
   private
 

--- a/app/views/profiles/edit_email.html.erb
+++ b/app/views/profiles/edit_email.html.erb
@@ -1,0 +1,30 @@
+<% content_for(:title, t('.title')) %>
+<div class="container">
+  <div class="col d-flex justify-content-end align-items-center">
+    <span class="d-inline-block my-3">
+      <%= link_to t('.to_top_page'), root_path, class: "custom-link" %>
+    </span>
+  </div>
+  <h1 class="text-center mt-3"><%= t('.title') %></h1>
+  <%= form_with(model: @user, url: update_email_profile_path, local: true) do |f| %>
+  <div class="card mt-5 custom-card-width mx-auto">
+    <div class="container py-2 my-5">
+      <div class="row justify-content-center">
+        <div class="col-md-8">
+          <div class="mb-3">
+            <%= f.label :current_email, class: 'form-label' %>
+            <%= f.text_field :email, class: 'form-control', value: User.find(current_user.id).email, readonly: true %>
+          </div>
+          <div class="mb-3">
+            <%= f.label :new_email, class: "form-label" %>
+            <%= f.text_field :email, class: "form-control", value: nil, required: true %>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="d-grid gap-2 col-4 mx-auto my-5">
+    <%= f.submit t('.update'), class: "btn btn-primary" %>
+  </div>
+  <% end %>
+</div>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -29,7 +29,7 @@
                 <%= f.email_field :email, class: 'form-control', value: @user.email, readonly: true %>
               </div>
               <div class="d-grid gap-2 col-3 mx-auto">
-                <%= link_to t('.edit'), "#", class: 'btn btn-primary', style: "letter-spacing: 5px; font-size: inherit; text-indent: initial;" %>
+                <%= link_to t('.edit'), edit_email_profile_path, class: 'btn btn-primary', style: "letter-spacing: 5px; font-size: inherit; text-indent: initial;" %>
               </div>
             </div>
           </div>

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -10,3 +10,5 @@ ja:
         password_confirmation: パスワード（確認用）
         current_name: 現在のユーザー名
         new_name: 新しいユーザー名
+        current_email: 現在のメールアドレス
+        new_email: 新しいメールアドレス

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -68,3 +68,7 @@ ja:
     update_username:
       success: ユーザー名を変更しました
       failure: ユーザー名の変更に失敗しました
+    edit_email:
+      to_top_page: トップページへ
+      title: メールアドレス編集
+      update: 変更する


### PR DESCRIPTION
fix #14 
# 概要
メールアドレス変更ページ作成
## 内容
- app/views/profiles/edit_email.html.erbを作成し、メールアドレス変更ページのレイアウトを記述しました。
- メールアドレス変更ページにアクセスできるよう、ルーティング、コントローラーを設定しました。
- ja.ymlファイルを更新し、メールアドレス変更ページのi18n対応をしました。
- .github/workflows/rspec.ymlファイルの記述を再度修正しました。