### PR TITLE
メールアドレス変更機能を実装

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,8 @@ FROM registry.docker.com/library/ruby:$RUBY_VERSION-slim as base
 # Rails app lives here
 WORKDIR /rails
 
+ENV TZ Asia/Tokyo
+
 # Set production environment
 ENV BUNDLE_DEPLOYMENT="1" \
     BUNDLE_PATH="/usr/local/bundle"

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -1,6 +1,6 @@
 class ProfilesController < ApplicationController
   before_action :require_login
-  before_action :set_user, only: %i[show edit_username update_username edit_email]
+  before_action :set_user, only: %i[show edit_username update_username edit_email update_email]
 
   def show; end
 
@@ -17,6 +17,15 @@ class ProfilesController < ApplicationController
 
   def edit_email; end
 
+  def update_email
+    if @user.update(email_params)
+      redirect_to profile_path, success: t('.success')
+    else
+      flash.now[:danger] = t('.failure')
+      render :edit_email, status: :unprocessable_entity
+    end
+  end
+
   private
 
   def set_user
@@ -25,5 +34,9 @@ class ProfilesController < ApplicationController
 
   def username_params
     params.require(:user).permit(:name)
+  end
+
+  def email_params
+    params.require(:user).permit(:email)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,7 +2,7 @@ class User < ApplicationRecord
   authenticates_with_sorcery!
 
   validates :name, presence: true, length: { maximum: 255 }
-  validates :email, presence: true, uniqueness: true
+  validates :email, presence: true, format: { with: URI::MailTo::EMAIL_REGEXP }, uniqueness: true
   validates :password, length: { minimum: 4 }, if: -> { new_record? || changes[:crypted_password] }
   validates :password, confirmation: true, if: -> { new_record? || changes[:crypted_password] }
   validates :password_confirmation, presence: true, if: -> { new_record? || changes[:crypted_password] }

--- a/compose.yaml
+++ b/compose.yaml
@@ -23,7 +23,8 @@ services:
       - db
       - selenium
     environment:
-      - SELENIUM_DRIVER_URL=http://selenium:4444/wd/hub
+      TZ: Asia/Tokyo
+      SELENIUM_DRIVER_URL: http://selenium:4444/wd/hub
     tty: true
     stdin_open: true
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -21,7 +21,8 @@ module MenuMaker
     # These settings can be overridden in specific environments using the files
     # in config/environments, which are processed later.
     #
-    # config.time_zone = "Central Time (US & Canada)"
+    config.time_zone = 'Tokyo'
+    config.active_record.default_timezone = :local
     # config.eager_load_paths << Rails.root.join("extras")
     config.generators do |g|
       g.skip_routes true

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -72,3 +72,6 @@ ja:
       to_top_page: トップページへ
       title: メールアドレス編集
       update: 変更する
+    update_email:
+    success: メールアドレスを変更しました
+    failure: メールアドレスの変更に失敗しました


### PR DESCRIPTION
fix #38 
# 概要
メールアドレス変更機能
## 内容
- メールアドレス変更機能を実装しました。
- 変更成功時、失敗時のフラッシュメッセージを設定しました。
- Docker環境、アプリケーションのタイムゾーンの設定をTokyoに修正しました。