### PR TITLE
パスワード変更機能を実装

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -12,24 +12,28 @@ jobs:
 
     services:
       postgres:
-        image: postgres:latest  # 最新バージョンのPostgreSQLイメージを使用
+        image: postgres:latest
         env:
           POSTGRES_DB: menu_maker_test
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: password
         ports:
           - 5432:5432
-        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
 
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
+      - name: Check out repository code
+        uses: actions/checkout@v4
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.3.2  # 使用するRubyのバージョンを指定
-          bundler-cache: true  # バンドラのキャッシュを有効にして、依存関係のインストールを高速化
+          ruby-version: 3.3.2
+          bundler-cache: true
 
       - name: Install dependencies
         run: |
@@ -39,7 +43,7 @@ jobs:
       - name: Setup database
         env:
           RAILS_ENV: test
-          DB_HOST: localhost
+          DB_HOST: postgres  # サービスコンテナのホスト名を指定
         run: |
           bundle exec rails db:create db:schema:load
 
@@ -48,6 +52,6 @@ jobs:
           bundle exec rspec
 
       - name: Show test results
-        if: success() || failure()  # テスト結果を表示するステップを成功/失敗にかかわらず実行
+        if: always()  # 成功または失敗にかかわらず、常に実行されるように変更
         run: |
-          echo "RSpec tests completed successfully"
+          echo "RSpec tests completed"

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -1,6 +1,6 @@
 class ProfilesController < ApplicationController
   before_action :require_login
-  before_action :set_user, only: %i[show edit_username update_username edit_email update_email edit_password]
+  before_action :set_user, only: %i[show edit_username update_username edit_email update_email edit_password update_password]
 
   def show; end
 
@@ -28,6 +28,16 @@ class ProfilesController < ApplicationController
 
   def edit_password; end
 
+  def update_password
+    if @user.valid_password?(password_params[:current_password]) &&
+       @user.update(password: password_params[:password], password_confirmation: password_params[:password_confirmation])
+      redirect_to profile_path, success: t('.success')
+    else
+      flash.now[:danger] = t('.failure')
+      render :edit_password, status: :unprocessable_entity
+    end
+  end
+
   private
 
   def set_user
@@ -40,5 +50,9 @@ class ProfilesController < ApplicationController
 
   def email_params
     params.require(:user).permit(:email)
+  end
+
+  def password_params
+    params.require(:user).permit(:current_password, :password, :password_confirmation)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,8 @@
 class User < ApplicationRecord
   authenticates_with_sorcery!
 
+  attr_accessor :current_password
+
   validates :name, presence: true, length: { maximum: 255 }
   validates :email, presence: true, format: { with: URI::MailTo::EMAIL_REGEXP }, uniqueness: true
   validates :password, length: { minimum: 4 }, if: -> { new_record? || changes[:crypted_password] }

--- a/app/views/profiles/edit_password.html.erb
+++ b/app/views/profiles/edit_password.html.erb
@@ -6,14 +6,14 @@
     </span>
   </div>
   <h1 class="text-center mt-3"><%= t('.title') %></h1>
-  <%= form_with(model: @user, url: update_email_profile_path, local: true) do |f| %>
+  <%= form_with(model: @user, url: update_password_profile_path, local: true) do |f| %>
   <div class="card mt-5 custom-card-width mx-auto">
     <div class="container py-2 my-5">
       <div class="row justify-content-center">
         <div class="col-md-8">
           <div class="mb-3">
             <%= f.label :current_password, class: 'form-label' %>
-            <%= f.password_field :password, class: "form-control", required: true %>
+            <%= f.password_field :current_password, class: "form-control", required: true %>
           </div>
           <div class="mb-3">
             <%= f.label :new_password, class: "form-label" %>

--- a/config/database.yml
+++ b/config/database.yml
@@ -59,7 +59,7 @@ development:
 test:
   <<: *default
   database: menu_maker_test
-  host: db
+  host: localhost
   port: 5432
   username: postgres
   password: password

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -79,3 +79,6 @@ ja:
       to_top_page: トップページへ
       title: パスワード変更
       update: 変更する
+    update_password:
+      success: パスワードを変更しました
+      failure: パスワードの変更に失敗しました


### PR DESCRIPTION
fix #39 
# 概要
パスワード変更機能
## 内容
- 以下の要件を満たした時にパスワードが変更できるように、パスワード変更機能を実装しました。
  - 現在のパスワードの入力フォームに入力した値が、現在設定しているパスワードと一致すること
  - 新しいパスワードと新しいパスワード（確認用）のフォームに入力した値が合致していること
  - 全ての入力フォームに値が入力されていること
  - 新しいパスワードと新しいパスワード（確認用）の値がバリデーションに引っかからないこと

- git push時にrspecテストが実行されるように、.github/workflows/rspec.ymlとconfig/database.ymを一部修正しました。