### PR TITLE
ユーザー名変更に関するテストコード作成

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -10,6 +10,9 @@ jobs:
     name: Run RSpec
     runs-on: ubuntu-latest
 
+    env:
+      SELENIUM_DRIVER_URL: http://selenium:4444/wd/hub
+
     services:
       postgres:
         image: postgres:latest

--- a/app/views/profiles/edit_username.html.erb
+++ b/app/views/profiles/edit_username.html.erb
@@ -17,7 +17,7 @@
           </div>
           <div class="mb-3">
             <%= f.label :new_name, class: "form-label" %>
-            <%= f.text_field :name, class: "form-control", value: nil, required: true %>
+            <%= f.text_field :name, class: "form-control", id: "new_name", value: nil %>
           </div>
         </div>
       </div>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -18,7 +18,7 @@
                 <%= f.text_field :name, class: 'form-control', value: @user.name, readonly: true %>
               </div>
               <div class="d-grid gap-2 col-3 mx-auto">
-                <%= link_to t('.edit'), edit_username_profile_path, class: 'btn btn-primary text-center', style: "letter-spacing: 5px; font-size: inherit; text-indent: initial;" %>
+                <%= link_to t('.edit'), edit_username_profile_path, id: 'edit_username_link', class: 'btn btn-primary text-center', style: "letter-spacing: 5px; font-size: inherit; text-indent: initial;" %>
               </div>
             </div>
           </div>

--- a/config/database.yml
+++ b/config/database.yml
@@ -59,7 +59,7 @@ development:
 test:
   <<: *default
   database: menu_maker_test
-  host: localhost
+  host: db
   port: 5432
   username: postgres
   password: password

--- a/spec/system/edit_username_spec.rb
+++ b/spec/system/edit_username_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+
+RSpec.describe 'ユーザー名の変更', type: :system do
+  let(:user) { create(:user) }
+
+  before do
+    login(user)
+    click_link 'マイページ'
+    click_link 'edit_username_link'
+  end
+
+  it '正しい情報を入力した場合、変更に成功すること' do
+    fill_in 'new_name', with: 'NewUsername'
+    click_button '変更'
+    visit profile_path
+    expect(user.reload.name).to eq 'NewUsername'
+  end
+
+  it '変更に成功した時にフラッシュメッセージが表示されること' do
+    fill_in 'new_name', with: 'NewUsername'
+    click_button '変更'
+    expect(page).to have_content 'ユーザー名を変更しました'
+  end
+
+  it 'ユーザー名が空の場合、エラーメッセージが表示される' do
+    fill_in 'new_name', with: ''
+    click_button '変更'
+    expect(page).to have_content 'ユーザー名の変更に失敗しました'
+  end
+end


### PR DESCRIPTION
fix #59 
# 概要
ユーザー名変更機能のテストコード作成
## 内容
- ユーザー名変更に関するシステムスペックのテストコードを作成しました。
- テストコード作成に伴い、以下のビューファイルを修正しました。
  - app/views/profiles/edit_username.html.erb
    - テストコードでフォームを指定できるよう、入力フォームにidを追加
  - app/views/profiles/show.html.erb
    - テストコードでリンクを指定できるよう、ユーザー編集ページへのリンクにidを追加
- .github/workflows/rspec.ymlとconfig/database.ymlの記述を一部修正しました。