### PR TITLE
メールアドレス変更に関するテストコードを作成

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Setup database
         env:
           RAILS_ENV: test
-          DB_HOST: postgres  # サービスコンテナのホスト名を指定
+          DB_HOST: db  # サービスコンテナのホスト名を指定
         run: |
           bundle exec rails db:create db:schema:load
 

--- a/app/views/profiles/edit_email.html.erb
+++ b/app/views/profiles/edit_email.html.erb
@@ -17,7 +17,7 @@
           </div>
           <div class="mb-3">
             <%= f.label :new_email, class: "form-label" %>
-            <%= f.text_field :email, class: "form-control", value: nil, required: true %>
+            <%= f.text_field :email, class: "form-control", id: "new_email", value: nil, required: true %>
           </div>
         </div>
       </div>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -29,7 +29,7 @@
                 <%= f.email_field :email, class: 'form-control', value: @user.email, readonly: true %>
               </div>
               <div class="d-grid gap-2 col-3 mx-auto">
-                <%= link_to t('.edit'), edit_email_profile_path, class: 'btn btn-primary', style: "letter-spacing: 5px; font-size: inherit; text-indent: initial;" %>
+                <%= link_to t('.edit'), edit_email_profile_path, id: 'edit_email_link', class: 'btn btn-primary', style: "letter-spacing: 5px; font-size: inherit; text-indent: initial;" %>
               </div>
             </div>
           </div>

--- a/spec/system/edit_email_spec.rb
+++ b/spec/system/edit_email_spec.rb
@@ -1,0 +1,41 @@
+require 'rails_helper'
+
+RSpec.describe 'メールアドレスの変更', type: :system do
+  let(:user) { create(:user) }
+
+  before do
+    login(user)
+    click_link 'マイページ'
+    click_link 'edit_email_link'
+  end
+
+  context "when 正しい情報が入力された場合" do
+    it '正しい情報を入力した場合、変更に成功すること' do
+      fill_in 'new_email', with: 'update@example.com'
+      click_button '変更'
+      visit profile_path
+      expect(user.reload.email).to eq 'update@example.com'
+    end
+
+    it '変更に成功した時にフラッシュメッセージが表示されること' do
+      fill_in 'new_email', with: 'update@example.com'
+      click_button '変更'
+      expect(page).to have_content 'メールアドレスを変更しました'
+    end
+  end
+
+  context "when 不正な情報が入力された場合" do
+    it 'メールアドレスの形式が不正な場合、エラーメッセージが表示される' do
+      fill_in 'new_email', with: 'update.example.com'
+      click_button '変更'
+      expect(page).to have_content 'メールアドレスの変更に失敗しました'
+    end
+
+    it 'すでに使用されているアドレスを入力した場合、エラーメッセージが表示される' do
+      create(:user, email: 'existing@example.com')
+      fill_in 'new_email', with: 'existing@example.com'
+      click_button '変更'
+      expect(page).to have_content 'メールアドレスの変更に失敗しました'
+    end
+  end
+end

--- a/spec/system/edit_username_spec.rb
+++ b/spec/system/edit_username_spec.rb
@@ -9,22 +9,26 @@ RSpec.describe 'ユーザー名の変更', type: :system do
     click_link 'edit_username_link'
   end
 
-  it '正しい情報を入力した場合、変更に成功すること' do
-    fill_in 'new_name', with: 'NewUsername'
-    click_button '変更'
-    visit profile_path
-    expect(user.reload.name).to eq 'NewUsername'
+  context "when 正しい情報が入力された場合" do
+    it '正しい情報を入力した場合、変更に成功すること' do
+      fill_in 'new_name', with: 'NewUsername'
+      click_button '変更'
+      visit profile_path
+      expect(user.reload.name).to eq 'NewUsername'
+    end
+
+    it '変更に成功した時にフラッシュメッセージが表示されること' do
+      fill_in 'new_name', with: 'NewUsername'
+      click_button '変更'
+      expect(page).to have_content 'ユーザー名を変更しました'
+    end
   end
 
-  it '変更に成功した時にフラッシュメッセージが表示されること' do
-    fill_in 'new_name', with: 'NewUsername'
-    click_button '変更'
-    expect(page).to have_content 'ユーザー名を変更しました'
-  end
-
-  it 'ユーザー名が空の場合、エラーメッセージが表示される' do
-    fill_in 'new_name', with: ''
-    click_button '変更'
-    expect(page).to have_content 'ユーザー名の変更に失敗しました'
+  context "when 不正な情報が入力された場合" do
+    it 'ユーザー名が空の場合、エラーメッセージが表示される' do
+      fill_in 'new_name', with: ''
+      click_button '変更'
+      expect(page).to have_content 'ユーザー名の変更に失敗しました'
+    end
   end
 end


### PR DESCRIPTION
fix #60 
# 概要
メールアドレス変更機能のテストコード作成
## 内容
- メールアドレスの変更機能に関するシステムスペックテストのテストコードを作成しました。
- テストコード作成に伴い、以下のファイルを修正しました。
  - app/views/profiles/show.html.erb
    - メールアドレスの編集ボタンにidを付与
  - spec/system/edit_username_spec.rb
    - メールアドレス入力フォームにidを付与
- その他.github/workflows/rspec.yml、spec/system/edit_username_spec.rbを一部修正しました。