### PR TITLE
パスワード変更機能に関するテストコードを作成

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -12,6 +12,7 @@ jobs:
 
     env:
       SELENIUM_DRIVER_URL: http://selenium:4444/wd/hub
+      DB_HOST: localhost  # GitHub Actions では localhost を使用
 
     services:
       postgres:
@@ -46,7 +47,8 @@ jobs:
       - name: Setup database
         env:
           RAILS_ENV: test
-          DB_HOST: db  # サービスコンテナのホスト名を指定
+          POSTGRES_HOST: localhost
+          POSTGRES_PORT: 5432
         run: |
           bundle exec rails db:create db:schema:load
 
@@ -55,6 +57,7 @@ jobs:
           bundle exec rspec
 
       - name: Show test results
-        if: always()  # 成功または失敗にかかわらず、常に実行されるように変更
+        if: always()
         run: |
           echo "RSpec tests completed"
+          

--- a/config/database.yml
+++ b/config/database.yml
@@ -59,7 +59,7 @@ development:
 test:
   <<: *default
   database: menu_maker_test
-  host: db
+  host: <%= ENV.fetch("DB_HOST", "db") %>
   port: 5432
   username: postgres
   password: password

--- a/spec/support/system_helper.rb
+++ b/spec/support/system_helper.rb
@@ -14,6 +14,15 @@ module SystemHelper
     fill_in 'password', with: 'password'
     click_button 'ログイン'
   end
+
+  def new_password_confirmation
+    fill_in 'user_current_password', with: 'password'
+    fill_in 'user_password', with: 'newpassword'
+    fill_in 'user_password_confirmation', with: 'newpassword'
+    click_button '変更する'
+    click_on 'ログアウト'
+    click_link 'ログイン'
+  end
 end
 
 RSpec.configure do |config|

--- a/spec/system/edit_email_spec.rb
+++ b/spec/system/edit_email_spec.rb
@@ -12,14 +12,14 @@ RSpec.describe 'メールアドレスの変更', type: :system do
   context "when 正しい情報が入力された場合" do
     it '正しい情報を入力した場合、変更に成功すること' do
       fill_in 'new_email', with: 'update@example.com'
-      click_button '変更'
+      click_button '変更する'
       visit profile_path
       expect(user.reload.email).to eq 'update@example.com'
     end
 
     it '変更に成功した時にフラッシュメッセージが表示されること' do
       fill_in 'new_email', with: 'update@example.com'
-      click_button '変更'
+      click_button '変更する'
       expect(page).to have_content 'メールアドレスを変更しました'
     end
   end
@@ -27,14 +27,14 @@ RSpec.describe 'メールアドレスの変更', type: :system do
   context "when 不正な情報が入力された場合" do
     it 'メールアドレスの形式が不正な場合、エラーメッセージが表示される' do
       fill_in 'new_email', with: 'update.example.com'
-      click_button '変更'
+      click_button '変更する'
       expect(page).to have_content 'メールアドレスの変更に失敗しました'
     end
 
     it 'すでに使用されているアドレスを入力した場合、エラーメッセージが表示される' do
       create(:user, email: 'existing@example.com')
       fill_in 'new_email', with: 'existing@example.com'
-      click_button '変更'
+      click_button '変更する'
       expect(page).to have_content 'メールアドレスの変更に失敗しました'
     end
   end

--- a/spec/system/edit_password_spec.rb
+++ b/spec/system/edit_password_spec.rb
@@ -1,0 +1,55 @@
+require 'rails_helper'
+
+RSpec.describe 'パスワードの変更', type: :system do
+  let(:user) { create(:user) }
+
+  before do
+    login(user)
+    click_link 'マイページ'
+    click_link 'パスワード変更'
+  end
+
+  context "when 正しい情報が入力された場合" do
+    it '変更に成功した時にフラッシュメッセージが表示されること' do
+      fill_in 'user_current_password', with: 'password'
+      fill_in 'user_password', with: 'newpassword'
+      fill_in 'user_password_confirmation', with: 'newpassword'
+      click_button '変更する'
+      expect(page).to have_content 'パスワードを変更しました'
+    end
+
+    it '変更後、新しいパスワードでログインできること' do
+      new_password_confirmation
+      fill_in 'email', with: user.email
+      fill_in 'password', with: 'newpassword'
+      click_button 'ログイン'
+      expect(page).to have_link('ログアウト')
+    end
+  end
+
+  context "when 不正な情報が入力された場合" do
+    it '現在のパスワードが一致しない時、エラーメッセージが表示される' do
+      fill_in 'user_current_password', with: 'different_password'
+      fill_in 'user_password', with: 'newpassword'
+      fill_in 'user_password_confirmation', with: 'newpassword'
+      click_button '変更する'
+      expect(page).to have_content 'パスワードの変更に失敗しました'
+    end
+
+    it '確認用のパスワードが一致しない時、エラーメッセージが表示される' do
+      fill_in 'user_current_password', with: 'password'
+      fill_in 'user_password', with: 'newpassword'
+      fill_in 'user_password_confirmation', with: 'different_password'
+      click_button '変更する'
+      expect(page).to have_content 'パスワードの変更に失敗しました'
+    end
+
+    it '新しいパスワードが4文字未満の時、エラーメッセージが表示される' do
+      fill_in 'user_current_password', with: 'password'
+      fill_in 'user_password', with: 'abc'
+      fill_in 'user_password_confirmation', with: 'abc'
+      click_button '変更する'
+      expect(page).to have_content 'パスワードの変更に失敗しました'
+    end
+  end
+end

--- a/spec/system/edit_username_spec.rb
+++ b/spec/system/edit_username_spec.rb
@@ -12,14 +12,14 @@ RSpec.describe 'ユーザー名の変更', type: :system do
   context "when 正しい情報が入力された場合" do
     it '正しい情報を入力した場合、変更に成功すること' do
       fill_in 'new_name', with: 'NewUsername'
-      click_button '変更'
+      click_button '変更する'
       visit profile_path
       expect(user.reload.name).to eq 'NewUsername'
     end
 
     it '変更に成功した時にフラッシュメッセージが表示されること' do
       fill_in 'new_name', with: 'NewUsername'
-      click_button '変更'
+      click_button '変更する'
       expect(page).to have_content 'ユーザー名を変更しました'
     end
   end
@@ -27,7 +27,7 @@ RSpec.describe 'ユーザー名の変更', type: :system do
   context "when 不正な情報が入力された場合" do
     it 'ユーザー名が空の場合、エラーメッセージが表示される' do
       fill_in 'new_name', with: ''
-      click_button '変更'
+      click_button '変更する'
       expect(page).to have_content 'ユーザー名の変更に失敗しました'
     end
   end


### PR DESCRIPTION
fix #61 
# 概要
パスワード変更のテストコード作成
## 内容
- パスワード変更に関するシステムスペックテストのテストコードを作成しました。
- 以下のファイルを一部修正しました。
  - .github/workflows/rspec.yml
  - config/database.yml
  - spec/system/edit_email_spec.rb
  - spec/system/edit_username_spec.rb