### PR TITLE
レシピ検索ページを作成

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -1,7 +1,7 @@
 name: RSpec Tests
 
 on:
-  push:
+  pull_request:
     branches:
       - main
 

--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -1,7 +1,7 @@
 name: Rubocop Tests
 
 on:
-  push:
+  pull_request:
     branches:
       - main
 

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -31,12 +31,12 @@ header {
   max-width: 100%;  /* 画像がコンテナを超えないように */
 }
 .custom-link {
-  color: #4C4C4C !important;
+  color: #4C4C4C;
   text-decoration: none; /* アンダーラインを消す場合 */
   font-size: 20px;
 }
 .custom-link:hover {
-  color: #61C359 !important; /* ホバー時に色を変える場合 */
+  color: #61C359; /* ホバー時に色を変える場合 */
 }
 
 .navbar-nav {
@@ -78,5 +78,16 @@ footer {
   text-indent: 10px;
 }
 .btn-secondary:hover {
+  background-color: #d07301 ; /* ホバー時の色 */
+}
+
+.btn-cookpad {
+  background-color: #F78700; /* ボタンの色　*/
+  border: none; /* ボーダーを消す　*/
+  letter-spacing: 10px; /* 文字の間隔　*/
+  font-size: 30px; /* 文字サイズ　*/
+  text-indent: 10px;
+}
+.btn-cookpad:hover {
   background-color: #d07301 ; /* ホバー時の色 */
 }

--- a/app/controllers/recipes_controller.rb
+++ b/app/controllers/recipes_controller.rb
@@ -1,0 +1,5 @@
+class RecipesController < ApplicationController
+  before_action :require_login
+
+  def search; end
+end

--- a/app/views/recipes/search.html.erb
+++ b/app/views/recipes/search.html.erb
@@ -1,0 +1,16 @@
+<% content_for(:title, t('.title')) %>
+<div class="container">
+  <div class="col d-flex justify-content-end align-items-center">
+    <span class="d-inline-block my-3">
+      <%= link_to t('.to_top_page'), root_path, class: "custom-link" %>
+    </span>
+  </div>
+  <h1 class="text-center my-5"><%= t('.title') %></h1>
+  <div class="container col-lg-9 mt-5 pt-3 mx-auto text-start">
+    <div class="d-grid gap-2 mx-auto">
+      <%= link_to t('.cookpad'), "https://cookpad.com/", class: 'btn btn-cookpad mb-5', target: "_blank" %>
+    </div>
+    <p>※ 現在、レシピの自動保存は「Cookpad」のレシピURLのみに対応しています。</p>
+    <p>※ 今後、「DELISH KITCHEN」や「クラシル」にも対応予定です。</p>
+  </div>
+</div>

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -2,7 +2,7 @@
   <div class="container-fluid">
     <div class="collapse navbar-collapse" id="navbarNavAltMarkup">
       <div class="navbar-nav w-100 nav-justified">
-        <%= link_to t('navbar.recipe_search'), "#", class: "nav-link #{active_if("#")}" %>
+        <%= link_to t('navbar.recipe_search'), search_recipes_path, class: "nav-link #{active_if("#")}" %>
         <%= link_to t('navbar.recipe_saving'), "#", class: "nav-link #{active_if("#")}" %>
         <%= link_to t('navbar.recipe_list'), "#", class: "nav-link #{active_if("#")}" %>
         <%= link_to t('navbar.menu_create'), "#", class: "nav-link #{active_if("#")}" %>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -78,4 +78,8 @@ Rails.application.configure do
   config.action_controller.raise_on_missing_callback_actions = true
 
   config.hosts << "menu-maker.fly.dev"
+
+  config.assets.compile = true
+  config.assets.debug = true
+  config.assets.digest = false
 end

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -82,3 +82,8 @@ ja:
     update_password:
       success: パスワードを変更しました
       failure: パスワードの変更に失敗しました
+  recipes:
+    search:
+      to_top_page: トップページへ
+      title: レシピ検索
+      cookpad: Cookpadから探す

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,6 +17,11 @@ Rails.application.routes.draw do
   post 'login', to: 'user_sessions#create'
   delete 'logout', to: 'user_sessions#destroy'
   resources :password_resets, only: %i[new create edit update]
+  resources :recipes do
+    collection do
+      get 'search'  # レシピ検索ページに対応するルート
+    end
+  end
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.

--- a/spec/system/user_registration_spec.rb
+++ b/spec/system/user_registration_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe "ユーザー登録機能", type: :system do
   it "ユーザー登録ページに正しいタイトルが表示されている" do
     visit new_user_path


### PR DESCRIPTION
fix #16 
# 概要
レシピ検索のページ作成
## 内容
- レシピ検索のページを作成し、cookpadへのリンクを設置しました。
- レシピ検索のページへアクセスできるように、recipes_controllerを作成してアクションを定義、ルーティングの設定をしました。
- rspec.ymlとrubocop.ymlファイルについて、プルリクエストが作成された時点でテストが実行されるように修正しました。
- cssの読み込みに関する設定を変更しました。