### PR TITLE
レシピの保存方法選択ページを作成

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-      SELENIUM_DRIVER_URL: http://selenium:4444/wd/hub
+      SELENIUM_DRIVER_URL: http://localhost:4444/wd/hub
       DB_HOST: localhost  # GitHub Actions では localhost を使用
 
     services:
@@ -28,6 +28,16 @@ jobs:
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
+
+      selenium:
+        image: selenium/standalone-chrome:latest
+        ports:
+          - 4444:4444
+        options: >-
+          --health-cmd="curl -f http://localhost:4444/wd/hub/status || exit 1"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=5
 
     steps:
       - name: Check out repository code

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -91,3 +91,29 @@ footer {
 .btn-cookpad:hover {
   background-color: #d07301 ; /* ホバー時の色 */
 }
+
+.save_options_auto {
+  background-color: #F78700;
+  width: 20em;
+  height: 20em;
+}
+.save_options_auto:hover {
+  background-color: #d07301 ;
+}
+.save_options_manual {
+  background-color: #FFD200;
+  width: 20em;
+  height: 20em;
+}
+.save_options_manual:hover {
+  background-color: #e7bd03;
+}
+.save_options {
+  background-color: #F5F5F5;
+}
+.card:hover .save_options {
+  background-color: #d9d6d6;
+}
+.small-font li {
+  font-size: 0.9em;
+}

--- a/app/controllers/recipes_controller.rb
+++ b/app/controllers/recipes_controller.rb
@@ -2,4 +2,6 @@ class RecipesController < ApplicationController
   before_action :require_login
 
   def search; end
+
+  def save_options; end
 end

--- a/app/views/recipes/save_options.html.erb
+++ b/app/views/recipes/save_options.html.erb
@@ -1,0 +1,43 @@
+<% content_for(:title, t('.title')) %>
+<div class="container">
+  <div class="col d-flex justify-content-end align-items-center">
+    <span class="d-inline-block my-3">
+      <%= link_to t('.to_top_page'), root_path, class: "custom-link" %>
+    </span>
+  </div>
+  <h1 class="text-center my-5"><%= t('.title') %></h1>
+  <div class="container p-5">
+    <div class="row">
+      <div class="col-6 d-flex justify-content-center">
+        <%= link_to "#", class: "card text-center save_options_auto text-decoration-none" do %>
+          <div class="card-body">
+            <div class="row px-4">
+              <div class="col-12 py-4 mt-5 d-flex justify-content-center align-items-center rounded-3 save_options">
+                <h2 class="card-title"><%= t('.auto_save') %></h2>
+              </div>
+            </div>
+            <h5 class="card-text mt-4"><%= t('.save_via_url') %></h5>
+          </div>
+        <% end %>
+      </div>
+      <div class="col-6 d-flex justify-content-center align-items-center">
+        <%= link_to "#", class: "card text-center save_options_manual text-decoration-none" do %>
+          <div class="card-body">
+            <div class="row px-4">
+              <div class="col-12 py-4 mt-5 d-flex justify-content-center align-items-center rounded-3 save_options">
+                <h2 class="card-title"><%= t('.manual_save') %></h2>
+              </div>
+            </div>
+            <h5 class="card-text my-4"><%= t('.save_manually') %></h5>
+            <div class="col-12 text-start ">
+              <ul class="small-font">
+                <li><%= t('.save_own_recipe') %></li>
+                <li><%= t('.cannot_save_automatically') %></li>
+              </ul>
+            </div>
+          </div>
+        <% end %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -2,8 +2,8 @@
   <div class="container-fluid">
     <div class="collapse navbar-collapse" id="navbarNavAltMarkup">
       <div class="navbar-nav w-100 nav-justified">
-        <%= link_to t('navbar.recipe_search'), search_recipes_path, class: "nav-link #{active_if("#")}" %>
-        <%= link_to t('navbar.recipe_saving'), "#", class: "nav-link #{active_if("#")}" %>
+        <%= link_to t('navbar.recipe_search'), search_recipes_path, class: "nav-link #{active_if('search_recipes_path')}" %>
+        <%= link_to t('navbar.recipe_saving'), save_options_recipes_path, class: "nav-link #{active_if('recipes/save_optionsds')}" %>
         <%= link_to t('navbar.recipe_list'), "#", class: "nav-link #{active_if("#")}" %>
         <%= link_to t('navbar.menu_create'), "#", class: "nav-link #{active_if("#")}" %>
       </div>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -87,3 +87,12 @@ ja:
       to_top_page: トップページへ
       title: レシピ検索
       cookpad: Cookpadから探す
+    save_options:
+      to_top_page: トップページへ
+      title: レシピの保存方法
+      auto_save: 自動で保存
+      save_via_url: 対象レシピのURL入力で保存
+      manual_save: 手動で保存
+      save_manually: レシピを手動で保存
+      save_own_recipe: 自作のレシピを保存する場合はこちら
+      cannot_save_automatically: 自動保存ができない場合はこちら

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,23 +5,24 @@ Rails.application.routes.draw do
   resources :users, only: %i[new create]
   resource :profile, only: %i[show] do
     collection do
-      get 'edit_username'
+      get 'edit_username'  # ユーザー名編集ページに対応するルート
       patch 'update_username'
-      get 'edit_email'
+      get 'edit_email'  # メールアドレス編集ページに対応するルート
       patch 'update_email'
-      get 'edit_password'
+      get 'edit_password'  # パスワード変更ページに対応するルート
       patch 'update_password'
     end
   end
-  get 'login', to: 'user_sessions#new'
-  post 'login', to: 'user_sessions#create'
-  delete 'logout', to: 'user_sessions#destroy'
   resources :password_resets, only: %i[new create edit update]
   resources :recipes do
     collection do
       get 'search'  # レシピ検索ページに対応するルート
+      get 'save_options'  # レシピ保存方法選択ページに対応するルート
     end
   end
+  get 'login', to: 'user_sessions#new'  # ログインページに対応するルート
+  post 'login', to: 'user_sessions#create'
+  delete 'logout', to: 'user_sessions#destroy'
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.


### PR DESCRIPTION
fix #17 
# 概要
レシピの保存方法選択ページ作成
## 内容
- レシピの保存方法を選択するページを作成しました。
- 作成したページにアクセスできるようにコントローラー、ルーティングの設定を行いました。
- .github/workflows/rspec.ymlを再度修正しました。