### PR TITLE
レシピの自動保存機能を実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -47,6 +47,9 @@ gem 'rails-i18n', '~> 7.0.0'
 gem 'sorcery', '~> 0.17.0'
 gem 'config'
 
+gem 'mechanize'
+gem 'rack-attack'
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri windows ]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -110,6 +110,7 @@ GEM
     diff-lcs (1.5.1)
     dockerfile-rails (1.6.17)
       rails (>= 3.0.0)
+    domain_name (0.6.20240107)
     drb (2.2.1)
     erubi (1.13.0)
     factory_bot (6.4.6)
@@ -126,6 +127,8 @@ GEM
     globalid (1.2.1)
       activesupport (>= 6.1)
     hashie (5.0.0)
+    http-cookie (1.0.6)
+      domain_name (~> 0.5)
     i18n (1.14.5)
       concurrent-ruby (~> 1.0)
     io-console (0.7.2)
@@ -162,7 +165,23 @@ GEM
       net-smtp
     marcel (1.0.4)
     matrix (0.4.2)
+    mechanize (2.10.1)
+      addressable (~> 2.8)
+      base64
+      domain_name (~> 0.5, >= 0.5.20190701)
+      http-cookie (~> 1.0, >= 1.0.3)
+      mime-types (~> 3.0)
+      net-http-digest_auth (~> 1.4, >= 1.4.1)
+      net-http-persistent (>= 2.5.2, < 5.0.dev)
+      nkf
+      nokogiri (~> 1.11, >= 1.11.2)
+      rubyntlm (~> 0.6, >= 0.6.3)
+      webrick (~> 1.7)
+      webrobots (~> 0.1.2)
     method_source (1.1.0)
+    mime-types (3.5.2)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2024.0702)
     mini_mime (1.1.5)
     minitest (5.24.0)
     msgpack (1.7.2)
@@ -171,6 +190,9 @@ GEM
     mutex_m (0.2.0)
     net-http (0.4.1)
       uri
+    net-http-digest_auth (1.4.1)
+    net-http-persistent (4.0.2)
+      connection_pool (~> 2.2)
     net-imap (0.4.14)
       date
       net-protocol
@@ -181,6 +203,7 @@ GEM
     net-smtp (0.5.0)
       net-protocol
     nio4r (2.7.3)
+    nkf (0.2.0)
     nokogiri (1.16.6-aarch64-linux)
       racc (~> 1.4)
     nokogiri (1.16.6-arm64-darwin)
@@ -218,6 +241,8 @@ GEM
       nio4r (~> 2.0)
     racc (1.8.0)
     rack (3.1.4)
+    rack-attack (6.7.0)
+      rack (>= 1.0, < 4)
     rack-session (2.0.0)
       rack (>= 3.0.0)
     rack-test (2.1.0)
@@ -307,6 +332,8 @@ GEM
     rubocop-rspec (3.0.1)
       rubocop (~> 1.61)
     ruby-progressbar (1.13.0)
+    rubyntlm (0.6.5)
+      base64
     rubyzip (2.3.2)
     selenium-webdriver (4.22.0)
       base64 (~> 0.2)
@@ -356,6 +383,7 @@ GEM
       rubyzip (>= 1.3.0)
       selenium-webdriver (~> 4.0)
     webrick (1.8.1)
+    webrobots (0.1.2)
     websocket (1.2.10)
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
@@ -380,9 +408,11 @@ DEPENDENCIES
   jbuilder
   jsbundling-rails
   letter_opener_web (~> 3.0)
+  mechanize
   pg (~> 1.1)
   pry-byebug
   puma (>= 5.0)
+  rack-attack
   rails (~> 7.1.3, >= 7.1.3.4)
   rails-i18n (~> 7.0.0)
   rspec-rails

--- a/app/controllers/recipes_controller.rb
+++ b/app/controllers/recipes_controller.rb
@@ -1,11 +1,98 @@
 class RecipesController < ApplicationController
+  require 'mechanize'
   before_action :require_login
 
   def search; end
 
   def save_options; end
 
-  def auto_save; end
+  def auto_save
+    @recipe = Recipe.new
+  end
 
-  def fetch_recipe; end
+  def fetch_recipe
+    # Mechanizeクラスをインスタンス化
+    agent = Mechanize.new
+    # 入力されたURLからWebページを取得
+    page = agent.get(fetch_recipe_params[:source_url])
+
+    # レシピの情報を取得
+    title = page.search('.recipe-title').text.strip
+    image_url = page.at('#main-photo img')['src']
+    source_url = fetch_recipe_params[:source_url]
+    source_site_name = Recipe.determine_source_site_name(source_url) # models/recipe.rbに定義したdetermine_source_site_nameメソッドでサイト名を取得
+    scraped_at = Time.current
+
+    if Recipe.exists?(source_url:) # 入力したURLがすでに存在する場合
+      existing_recipe = current_user.recipes.find_by(source_url:)
+      existing_recipe.update(title:, image_url:, scraped_at:)
+
+      # 材料の情報を更新または作成
+      page.search('.ingredient_row').each do |ingredient_row|
+        name = ingredient_row.at('.ingredient_name .name').text
+        quantity_text = ingredient_row.at('.ingredient_quantity.amount').text.strip
+        quantity, unit = Recipe.parse_quantity_and_unit(quantity_text)
+
+        # 既存の材料を探す
+        existing_ingredient = existing_recipe.ingredients.find_by(name:) # 材料名が同じingredientsの情報を探す
+        if existing_ingredient
+          existing_ingredient.update(quantity:, unit:)
+        else
+          existing_recipe.ingredients.build(name:, quantity:, unit:)
+        end
+      end
+
+      # 手順の情報を更新または作成
+      page.search('.step').each_with_index do |step, index|
+        description = step.text.strip
+
+        # 既存の手順を探す
+        existing_instruction = existing_recipe.instructions.find_by(step_number: index + 1)
+        if existing_instruction
+          existing_instruction.update(description:)
+        else
+          existing_recipe.instructions.build(step_number: index + 1, description:)
+        end
+      end
+
+      if existing_recipe.save
+        flash[:success] = t('.update_success')
+      else
+        flash[:error] = t('.update_failure')
+      end
+    else
+      # レシピを作成
+      @recipe = current_user.recipes.new(title:, image_url:, source_url:, source_site_name:, scraped_at:)
+
+      # 材料の情報を取得して@recipeに関連付け
+      page.search('.ingredient_row').each do |ingredient_row| # '.ingredient_row'クラスを持つ要素を全て検索し、それぞれの要素について処理を行う
+        name = ingredient_row.at('.ingredient_name .name').text
+        quantity_text = ingredient_row.at('.ingredient_quantity.amount').text.strip
+        quantity, unit = Recipe.parse_quantity_and_unit(quantity_text) # models/recipe.rbに定義したparse_quantity_and_unitメソッドで量と単位を取得
+
+        @recipe.ingredients.build(name:, quantity:, unit:)
+      end
+
+      # 手順の情報を取得して追加
+      page.search('.step').each_with_index do |step, index| # '.step'クラスを持つ要素をすべて検索し、それぞれの要素について処理を行う
+        description = step.text.strip
+        @recipe.instructions.build(step_number: index + 1, description:)
+      end
+
+      # 保存成功、失敗時のメッセージ表示
+      if @recipe.save
+        flash[:success] = t('.success')
+      else
+        flash[:error] = t('.failure')
+      end
+    end
+
+    redirect_to root_path
+  end
+
+  private
+
+  def fetch_recipe_params
+    params.require(:recipe).permit(:source_url)
+  end
 end

--- a/app/models/ingredient.rb
+++ b/app/models/ingredient.rb
@@ -1,0 +1,7 @@
+class Ingredient < ApplicationRecord
+  belongs_to :recipe
+
+  validates :name, presence: true
+  validates :unit, presence: true
+  validates :quantity, numericality: true, allow_nil: true
+end

--- a/app/models/instruction.rb
+++ b/app/models/instruction.rb
@@ -1,0 +1,6 @@
+class Instruction < ApplicationRecord
+  belongs_to :recipe
+
+  validates :step_number, presence: true, numericality: { only_integer: true, greater_than: 0 }
+  validates :description, presence: true, length: { maximum: 500 }
+end

--- a/app/models/recipe.rb
+++ b/app/models/recipe.rb
@@ -1,0 +1,35 @@
+class Recipe < ApplicationRecord
+  belongs_to :user
+  has_many :ingredients, dependent: :destroy
+  has_many :instructions, dependent: :destroy
+
+  validates :title, presence: true
+  validates :image_url, presence: true, format: { with: URI::DEFAULT_PARSER.make_regexp }
+  validates :source_url, presence: true, format: { with: URI::DEFAULT_PARSER.make_regexp }
+  validates :source_site_name, presence: true
+
+  def self.determine_source_site_name(url)
+    require 'uri'
+    uri = URI.parse(url) # URLを解析して、その結果をuriに入れる
+    host = uri.host # 解析したURLのホスト名（ドメイン）を取得
+
+    case host # 取得したホスト名についての条件分岐
+    when 'cookpad.com'
+      'Cookpad' # ホスト名が'cookpad.com'のときに'Cookpad'を返す
+    else
+      host # 条件に当てはまらない場合は、ホスト名をそのまま返す
+    end
+  end
+
+  def self.parse_quantity_and_unit(quantity_text)
+    match_data = quantity_text.match(/(\d+)\s*(.+)/) # 数量と単位を分離
+    if match_data # 数量と単位が分離できた場合
+      quantity = match_data[1].to_i # 数量を数値に変換
+      unit = match_data[2].strip # 単位を取得（余分な空白を削除）
+    else
+      quantity = nil
+      unit = quantity_text.strip # 数量がない場合（適量など）はquantity_text全体をunitに設定
+    end
+    [quantity, unit]
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,6 @@
 class User < ApplicationRecord
+  has_many :recipes, dependent: :destroy
+
   authenticates_with_sorcery!
 
   attr_accessor :current_password

--- a/app/views/recipes/auto_save.html.erb
+++ b/app/views/recipes/auto_save.html.erb
@@ -7,10 +7,10 @@
   </div>
   <h1 class="text-center my-5"><%= t('.title') %></h1>
   <div class="container py-5 px-5">
-    <%= form_with url: fetch_recipe_recipes_path, method: :post do |f| %>
+    <%= form_with model: @recipe, url: fetch_recipe_recipes_path do |f| %>
       <div class="mb-5">
         <%= f.label :source_url, class: "form-label mx-auto" %>
-        <%= f.text_field :source_url, class: "form-control mx-auto", placeholder: t('.enter_the_url') %>
+        <%= f.text_field :source_url, class: "form-control mx-auto", placeholder: t('.enter_the_url'), required: true %>
       </div>
       <div class="d-grid gap-2 col-4 mx-auto">
         <%= f.submit t('.fetch_recipe'), class: "btn btn-primary" %>

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -1,0 +1,6 @@
+# /recipes/fetch_recipe のPOSTリクエストに対して、1秒間に1回の制限
+Rack::Attack.throttle('recipes/fetch_recipe', limit: 1, period: 1.seconds) do |req|
+  if req.path == '/recipes/fetch_recipe' && req.post?
+    req.remote_ip
+  end
+end

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -101,3 +101,8 @@ ja:
       title: レシピの自動保存
       enter_the_url: レシピページのURLを入力してください
       fetch_recipe: レシピを保存
+    fetch_recipe:
+      success: レシピを保存しました
+      failure: レシピの保存に失敗しました
+      update_success: レシピを更新しました
+      failure_success: レシピの更新に失敗しました

--- a/db/migrate/20240712011555_create_recipes.rb
+++ b/db/migrate/20240712011555_create_recipes.rb
@@ -1,0 +1,14 @@
+class CreateRecipes < ActiveRecord::Migration[7.1]
+  def change
+    create_table :recipes do |t|
+      t.references :user, null: false, foreign_key: true
+      t.string :title
+      t.string :image_url
+      t.string :source_url
+      t.string :source_site_name
+      t.datetime :scraped_at
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20240712011729_create_ingredients.rb
+++ b/db/migrate/20240712011729_create_ingredients.rb
@@ -1,0 +1,12 @@
+class CreateIngredients < ActiveRecord::Migration[7.1]
+  def change
+    create_table :ingredients do |t|
+      t.references :recipe, null: false, foreign_key: true
+      t.string :name
+      t.string :quantity
+      t.string :unit
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20240712011848_create_instructions.rb
+++ b/db/migrate/20240712011848_create_instructions.rb
@@ -1,0 +1,11 @@
+class CreateInstructions < ActiveRecord::Migration[7.1]
+  def change
+    create_table :instructions do |t|
+      t.references :recipe, null: false, foreign_key: true
+      t.integer :step_number
+      t.text :description
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,40 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_07_06_145600) do
+ActiveRecord::Schema[7.1].define(version: 2024_07_12_011848) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "ingredients", force: :cascade do |t|
+    t.bigint "recipe_id", null: false
+    t.string "name"
+    t.string "quantity"
+    t.string "unit"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["recipe_id"], name: "index_ingredients_on_recipe_id"
+  end
+
+  create_table "instructions", force: :cascade do |t|
+    t.bigint "recipe_id", null: false
+    t.integer "step_number"
+    t.text "description"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["recipe_id"], name: "index_instructions_on_recipe_id"
+  end
+
+  create_table "recipes", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.string "title"
+    t.string "image_url"
+    t.string "source_url"
+    t.string "source_site_name"
+    t.datetime "scraped_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_recipes_on_user_id"
+  end
 
   create_table "users", force: :cascade do |t|
     t.string "email", null: false
@@ -29,4 +60,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_06_145600) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "ingredients", "recipes"
+  add_foreign_key "instructions", "recipes"
+  add_foreign_key "recipes", "users"
 end

--- a/spec/factories/ingredients.rb
+++ b/spec/factories/ingredients.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :ingredient do
+    recipe { nil }
+    name { "MyString" }
+    quantity { "MyString" }
+    unit { "MyString" }
+  end
+end

--- a/spec/factories/instructions.rb
+++ b/spec/factories/instructions.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :instruction do
+    recipe { nil }
+    step_number { 1 }
+    description { "MyText" }
+  end
+end

--- a/spec/factories/recipes.rb
+++ b/spec/factories/recipes.rb
@@ -1,0 +1,10 @@
+FactoryBot.define do
+  factory :recipe do
+    user { nil }
+    title { "MyString" }
+    image_url { "MyString" }
+    source_url { "MyString" }
+    source_site_name { "MyString" }
+    scraped_at { "2024-07-12 10:15:55" }
+  end
+end

--- a/spec/models/ingredient_spec.rb
+++ b/spec/models/ingredient_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Ingredient, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/instruction_spec.rb
+++ b/spec/models/instruction_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Instruction, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/recipe_spec.rb
+++ b/spec/models/recipe_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Recipe, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
fix #72 ,
fis #73 
# 概要
レシピの自動保存機能の実装準備
レシピの自動保存機能
## 内容
- 以下の項目を実施し、URL入力によるレシピの自動保存機能を実装しました。
  - 以下のgemをインストール
    - gem 'mechanize'
    - gem 'rack-attack'
  - 以下のテーブルを作成し、バリデーションとアソシエーションを設定
    - recipes
    - ingredients
    - instructions
  - usersテーブルに関してもアソシエーションを設定
  - recipes_controllerに自動保存のアクションを定義し、ルーティングを設定
  - viewのURL入力フォームの記述を修正