### PR TITLE
レシピの手動保存ページを作成

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -117,3 +117,27 @@ footer {
 .small-font li {
   font-size: 0.9em;
 }
+
+.custom-card-manual-save {
+  max-width: 90%; /* 必要に応じて調整 */
+  margin: auto; /* カードを中央揃えにする */
+  background-color: #FFD982;
+}
+
+.form-group {
+  margin-bottom: 20px; /* フォームとボタンの間に20pxの間隔を追加 */
+}
+.btn-manual_save {
+  background-color: #e2e1df; /* ボタンの色　*/
+  border: none; /* ボーダーを消す　*/
+  font-size: 15px; /* 文字サイズ　*/
+}
+.btn-manual_save:hover {
+  background-color: #c7c6c4;
+}
+
+.btn-danger {
+  background-color: #F68655;
+  width: 40px;
+  height: 40px;
+}

--- a/app/controllers/recipes_controller.rb
+++ b/app/controllers/recipes_controller.rb
@@ -90,6 +90,12 @@ class RecipesController < ApplicationController
     redirect_to root_path
   end
 
+  def new
+    @recipe = Recipe.new
+    @recipe.ingredients.build
+    @recipe.instructions.build
+  end
+
   private
 
   def fetch_recipe_params

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,3 +1,4 @@
 // Entry point for the build script in your package.json
+import "@hotwired/stimulus"
 import "@hotwired/turbo-rails"
 import "./controllers"

--- a/app/javascript/controllers/dynamic_form_controller.js
+++ b/app/javascript/controllers/dynamic_form_controller.js
@@ -1,0 +1,86 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["nestedForms"]
+
+  connect() {
+    // 初期フォームの数を取得
+    this.initialFormCount = this.nestedFormsTarget.querySelectorAll('.instruction-fields, .ingredient-fields').length;
+    // カウンターを初期フォームの数からスタートさせる
+    this.instructionCount = this.initialFormCount;
+
+    // 削除ボタンがクリックされたときのイベントリスナーを追加
+    this.element.addEventListener('click', (event) => {
+      if (event.target.classList.contains('remove-instruction') || event.target.classList.contains('remove-ingredient')) {
+        this.removeForm(event);
+      }
+    });
+  }
+
+  addIngredientForm(event) {
+    event.preventDefault();
+    const newForm = document.querySelector('.ingredient-fields').cloneNode(true);
+    const timestamp = new Date().getTime();
+    newForm.innerHTML = newForm.innerHTML.replace(/_attributes_\d+_/g, `_attributes_${timestamp}_`);
+
+    // 新しいフォームに削除ボタンを追加する
+    const removeButton = this.createRemoveButton('ingredient');
+    const formRow = newForm.querySelector('.row');
+    formRow.appendChild(removeButton);
+    
+    // Insert newForm before the add ingredient link
+    const addIngredientLink = this.element.querySelector('.add-ingredient');
+    this.nestedFormsTarget.insertBefore(newForm, addIngredientLink);
+  }
+
+  addInstructionForm(event) {
+    event.preventDefault();
+    const newForm = document.querySelector('.instruction-fields').cloneNode(true);
+    const timestamp = new Date().getTime();
+    newForm.innerHTML = newForm.innerHTML.replace(/_attributes_\d+_/g, `_attributes_${timestamp}_`);
+
+    // 新しいフォームに番号を付ける
+    newForm.querySelector('input[name*="[step_number]"]').value = ++this.instructionCount;
+
+    // 新しいフォームに削除ボタンを追加する
+    const removeButton = this.createRemoveButton('instruction');
+    const formRow = newForm.querySelector('.row');
+    formRow.appendChild(removeButton);
+    
+    // Insert newForm before the add instruction link
+    const addInstructionLink = this.element.querySelector('.add-instruction');
+    this.nestedFormsTarget.insertBefore(newForm, addInstructionLink);
+  }
+
+  removeForm(event) {
+    event.preventDefault();
+    const formContainer = event.target.closest('.instruction-fields, .ingredient-fields');
+    if (formContainer && formContainer.dataset.newForm !== 'true') {
+      formContainer.remove();
+      this.recalculateStepNumbers();
+    }
+  }
+
+  recalculateStepNumbers() {
+    // 全てのフォームを取得し直す
+    const forms = this.nestedFormsTarget.querySelectorAll('.instruction-fields, .ingredient-fields');
+    this.instructionCount = 0;
+
+    // 各フォームの番号を再設定する
+    forms.forEach((form, index) => {
+      const stepNumberInput = form.querySelector('input[name*="[step_number]"]');
+      if (stepNumberInput) {
+        stepNumberInput.value = ++this.instructionCount;
+      }
+    });
+  }
+
+  createRemoveButton(type) {
+    const removeButton = document.createElement('a');
+    removeButton.href = '#';
+    removeButton.textContent = 'x';
+    removeButton.className = `remove-${type} btn btn-danger`;
+    removeButton.setAttribute('data-action', 'click->dynamic-form#removeForm');
+    return removeButton;
+  }
+}

--- a/app/javascript/controllers/hello_controller.js
+++ b/app/javascript/controllers/hello_controller.js
@@ -1,7 +1,0 @@
-import { Controller } from "@hotwired/stimulus"
-
-export default class extends Controller {
-  connect() {
-    this.element.textContent = "Hello World!"
-  }
-}

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -4,5 +4,8 @@
 
 import { application } from "./application"
 
-import HelloController from "./hello_controller"
-application.register("hello", HelloController)
+import DynamicFormController from "./dynamic_form_controller"
+
+application.register("dynamic-form", DynamicFormController) // 新しいコントローラーを追加
+
+export default application

--- a/app/models/recipe.rb
+++ b/app/models/recipe.rb
@@ -3,6 +3,9 @@ class Recipe < ApplicationRecord
   has_many :ingredients, dependent: :destroy
   has_many :instructions, dependent: :destroy
 
+  accepts_nested_attributes_for :ingredients, reject_if: :all_blank, allow_destroy: true
+  accepts_nested_attributes_for :instructions, reject_if: :all_blank, allow_destroy: true
+
   validates :title, presence: true
   validates :image_url, presence: true, format: { with: URI::DEFAULT_PARSER.make_regexp }
   validates :source_url, presence: true, format: { with: URI::DEFAULT_PARSER.make_regexp }

--- a/app/views/recipes/_ingredient_fields.html.erb
+++ b/app/views/recipes/_ingredient_fields.html.erb
@@ -1,0 +1,7 @@
+<div class="container ingredient-fields mb-2">
+  <div class="row">
+    <%= f.text_field :name, placeholder: t('ingredient_fields.ingredient_name'), style: 'width: 200px; height: 40px;' %>
+    <%= f.text_field :quantity, placeholder: t('ingredient_fields.quantity'), style: 'width: 80px; height: 40px;' %>
+    <%= f.text_field :unit, placeholder: t('ingredient_fields.unit'), style: 'width: 80px; height: 40px;'  %>
+  </div>
+</div>

--- a/app/views/recipes/_instruction_fields.html.erb
+++ b/app/views/recipes/_instruction_fields.html.erb
@@ -1,0 +1,6 @@
+<div class="container instruction-fields mb-2">
+  <div class="row">
+    <%= f.text_field :step_number, style: 'width: 40px; height: 40px;', value: f.object.step_number || 1, readonly: true %> 
+    <%= f.text_area :description, placeholder: t('instruction_fields.instruction_description'), style: 'width: 350px; height: 100px;' %>
+  </div>
+</div>

--- a/app/views/recipes/new.html.erb
+++ b/app/views/recipes/new.html.erb
@@ -1,0 +1,48 @@
+<% content_for(:title, t('.title')) %>
+<div class="container">
+  <div class="col d-flex justify-content-end align-items-center">
+    <span class="d-inline-block my-3">
+      <%= link_to t('.to_top_page'), root_path, class: "custom-link" %>
+    </span>
+  </div>
+  <h1 class="text-center mt-3"><%= t('.title') %></h1>
+  <%= form_with model: @recipe, local: true do |f| %>
+  <div class="card mt-5 custom-card-manual-save mx-auto">
+    <div class="row mt-5 d-flex justify-content-center">
+      <div class="col-10 text-start">
+        <%= f.label :recipe_title, class: 'form-label', style: 'font-size: 30px;' %>
+        <%= f.text_field :title, class: 'form-label', style: 'width: 680px; height: 50px;' %>
+      </div>
+    </div>
+    <div class="container py-2 my-5">
+      <div class="row">
+        <div class="col-6 d-flex justify-content-center">
+          <div id="ingredients-form" data-controller="dynamic-form" data-dynamic-form-target="nestedForms">
+            <h4><%= t('.ingredients') %></h4>
+            <%= f.fields_for :ingredients do |ingredient_fields| %>
+              <%= render 'ingredient_fields', f: ingredient_fields %>
+            <% end %>
+            <%= link_to t('.add_ingredient'), '#', class: 'add-ingredient btn btn-manual_save mt-5', data: { action: 'click->dynamic-form#addIngredientForm' } %>
+          </div>
+        </div>
+        <div class="col-6 d-flex justify-content-center">
+          <div id="instructions-form" data-controller="dynamic-form" data-dynamic-form-target="nestedForms">
+            <h4><%= t('.instructions') %></h4>
+            <%= f.fields_for :instructions  do |instruction_fields| %>
+              <%= render 'instruction_fields', f: instruction_fields %>
+            <% end %>
+            <%= link_to t('.add_instruction'), '#', class: 'add-instruction btn btn-manual_save mt-5', data: { action: 'click->dynamic-form#addInstructionForm' } %>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="d-grid gap-2 col-4 mx-auto my-5">
+    <%= f.submit t('.save'), class: "btn btn-primary" %>
+  </div>
+  <% end %>
+
+  <%= turbo_frame_tag 'dynamic-forms' do %>
+    <!-- Empty turbo frame for dynamic form updates -->
+  <% end %>
+</div>

--- a/app/views/recipes/save_options.html.erb
+++ b/app/views/recipes/save_options.html.erb
@@ -21,7 +21,7 @@
         <% end %>
       </div>
       <div class="col-6 d-flex justify-content-center align-items-center">
-        <%= link_to "#", class: "card text-center save_options_manual text-decoration-none" do %>
+        <%= link_to new_recipe_path, class: "card text-center save_options_manual text-decoration-none" do %>
           <div class="card-body">
             <div class="row px-4">
               <div class="col-12 py-4 mt-5 d-flex justify-content-center align-items-center rounded-3 save_options">

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -17,3 +17,4 @@ ja:
         new_password_confirmation: 新しいパスワード（確認用）
       recipe:
         source_url: URLを入力
+        recipe_title: レシピ名

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -106,3 +106,19 @@ ja:
       failure: レシピの保存に失敗しました
       update_success: レシピを更新しました
       failure_success: レシピの更新に失敗しました
+    new:
+      to_top_page: トップページへ
+      title: レシピの手動保存
+      ingredients: 材料
+      add_ingredient: 材料のフォームを追加
+      instructions: 作り方
+      add_instruction: 作り方のフォームを追加
+      save: レシピを保存
+  ingredient_fields:
+    ingredient_name: 材料名
+    quantity: 量
+    unit: 単位
+    remove: x
+  instruction_fields:
+    instruction_description: 作り方を入力
+    remove: x


### PR DESCRIPTION
fix #19 
# 概要
レシピの手動保存ページ作成
## 内容
- レシピを手動保存するための入力ページを作成しました。
  - 材料、作り方の入力フォームはstimulusを利用して動的に追加、削除できるように設定しました。
- 手動保存ページが機能するよう、コントローラー、ルーティング、モデルの設定をしました。