### PR TITLE
レシピの詳細ページを作成

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -181,3 +181,9 @@ footer {
   background-color: #cf7047;
   color: #dbd8d8;
 }
+
+.subtitle {
+  background-color: #F6B352;
+  text-align: center;
+  letter-spacing: 5px;
+}

--- a/app/controllers/recipes_controller.rb
+++ b/app/controllers/recipes_controller.rb
@@ -23,8 +23,8 @@ class RecipesController < ApplicationController
     source_site_name = Recipe.determine_source_site_name(source_url)
     scraped_at = Time.current
 
-    if Recipe.exists?(source_url: source_url) # 入力したURLがすでに存在する場合
-      existing_recipe = current_user.recipes.find_by(source_url: source_url)
+    if Recipe.exists?(source_url:) # 入力したURLがすでに存在する場合
+      existing_recipe = current_user.recipes.find_by(source_url:)
       if existing_recipe.update(title:, scraped_at:)
         update_ingredients_and_instructions(existing_recipe, page)
 
@@ -62,6 +62,10 @@ class RecipesController < ApplicationController
     @recipes = current_user.recipes.includes(:ingredients)
   end
 
+  def show
+    @recipe = Recipe.find(params[:id])
+  end
+
   def new
     @recipe = Recipe.new
     @recipe.ingredients.build
@@ -76,10 +80,6 @@ class RecipesController < ApplicationController
       flash.now[:danger] = t('.failure')
       render :new, status: :unprocessable_entity
     end
-  end
-
-  def show
-    @recipe = Recipe.find(params[:id])
   end
 
   private
@@ -106,7 +106,7 @@ class RecipesController < ApplicationController
       quantity, unit = Recipe.parse_quantity_and_unit(quantity_text)
       updated_at = Time.current
 
-      existing_ingredient = recipe.ingredients.find_by(name: name)
+      existing_ingredient = recipe.ingredients.find_by(name:)
       if existing_ingredient
         existing_ingredient.update(quantity:, unit:, updated_at:)
       else
@@ -120,7 +120,7 @@ class RecipesController < ApplicationController
 
       existing_instruction = recipe.instructions.find_by(step_number: index + 1)
       if existing_instruction
-        existing_instruction.update(description: description, updated_at:)
+        existing_instruction.update(description:, updated_at:)
       else
         recipe.instructions.build(step_number: index + 1, description:, updated_at:)
       end

--- a/app/controllers/recipes_controller.rb
+++ b/app/controllers/recipes_controller.rb
@@ -18,76 +18,44 @@ class RecipesController < ApplicationController
 
     # レシピの情報を取得
     title = page.search('.recipe-title').text.strip
-    image = page.at('#main-photo img')['src']
+    image_url = page.at('#main-photo img')['src']
     source_url = fetch_recipe_params[:source_url]
-    source_site_name = Recipe.determine_source_site_name(source_url) # models/recipe.rbに定義したdetermine_source_site_nameメソッドでサイト名を取得
+    source_site_name = Recipe.determine_source_site_name(source_url)
     scraped_at = Time.current
 
-    if Recipe.exists?(source_url:) # 入力したURLがすでに存在する場合
-      existing_recipe = current_user.recipes.find_by(source_url:)
-      existing_recipe.update(title:, image:, scraped_at:)
+    if Recipe.exists?(source_url: source_url) # 入力したURLがすでに存在する場合
+      existing_recipe = current_user.recipes.find_by(source_url: source_url)
+      if existing_recipe.update(title:, scraped_at:)
+        update_ingredients_and_instructions(existing_recipe, page)
 
-      # 材料の情報を更新または作成
-      page.search('.ingredient_row').each do |ingredient_row|
-        name = ingredient_row.at('.ingredient_name .name').text
-        quantity_text = ingredient_row.at('.ingredient_quantity.amount').text.strip
-        quantity, unit = Recipe.parse_quantity_and_unit(quantity_text)
-
-        # 既存の材料を探す
-        existing_ingredient = existing_recipe.ingredients.find_by(name:) # 材料名が同じingredientsの情報を探す
-        if existing_ingredient
-          existing_ingredient.update(quantity:, unit:)
-        else
-          existing_recipe.ingredients.build(name:, quantity:, unit:)
+        # 画像のダウンロードとアップロード
+        if image_url.present?
+          existing_recipe.remote_image_url = image_url
+          existing_recipe.save
         end
-      end
 
-      # 手順の情報を更新または作成
-      page.search('.step').each_with_index do |step, index|
-        description = step.text.strip
-
-        # 既存の手順を探す
-        existing_instruction = existing_recipe.instructions.find_by(step_number: index + 1)
-        if existing_instruction
-          existing_instruction.update(description:)
-        else
-          existing_recipe.instructions.build(step_number: index + 1, description:)
-        end
-      end
-
-      if existing_recipe.save
-        flash[:success] = t('.update_success')
+        redirect_to recipes_path, success: t('.update_success')
       else
-        flash[:danger] = t('.update_failure')
+        flash.now[:danger] = t('.update_failure')
+        render :auto_save, status: :unprocessable_entity
       end
     else
       # レシピを作成
-      @recipe = current_user.recipes.new(title:, image:, source_url:, source_site_name:, scraped_at:)
+      @recipe = current_user.recipes.new(title:, source_url:, source_site_name:, scraped_at:)
+      set_ingredients_and_instructions(@recipe, page)
 
-      # 材料の情報を取得して@recipeに関連付け
-      page.search('.ingredient_row').each do |ingredient_row| # '.ingredient_row'クラスを持つ要素を全て検索し、それぞれの要素について処理を行う
-        name = ingredient_row.at('.ingredient_name .name').text
-        quantity_text = ingredient_row.at('.ingredient_quantity.amount').text.strip
-        quantity, unit = Recipe.parse_quantity_and_unit(quantity_text) # models/recipe.rbに定義したparse_quantity_and_unitメソッドで量と単位を取得
-
-        @recipe.ingredients.build(name:, quantity:, unit:)
-      end
-
-      # 手順の情報を取得して追加
-      page.search('.step').each_with_index do |step, index| # '.step'クラスを持つ要素をすべて検索し、それぞれの要素について処理を行う
-        description = step.text.strip
-        @recipe.instructions.build(step_number: index + 1, description:)
-      end
-
-      # 保存成功、失敗時のメッセージ表示
+      # 画像のダウンロードとアップロードは保存後に行う
       if @recipe.save
-        flash[:success] = t('.success')
+        if image_url.present?
+          @recipe.remote_image_url = image_url
+          @recipe.save
+        end
+        redirect_to recipes_path, success: t('.success')
       else
-        flash[:danger] = t('.failure')
+        flash.now[:danger] = t('.failure')
+        render :auto_save, status: :unprocessable_entity
       end
     end
-
-    redirect_to root_path
   end
 
   def index
@@ -102,7 +70,6 @@ class RecipesController < ApplicationController
 
   def create
     @recipe = current_user.recipes.new(recipe_params)
-
     if @recipe.save
       redirect_to root_path, success: t('.success')
     else
@@ -111,13 +78,66 @@ class RecipesController < ApplicationController
     end
   end
 
+  def show
+    @recipe = Recipe.find(params[:id])
+  end
+
   private
 
   def fetch_recipe_params
     params.require(:recipe).permit(:source_url)
   end
 
+  def download_and_store_image(url, recipe)
+    uploader = ImageUploader.new(recipe, :image)
+    uploader.download!(url)
+    uploader.store!
+    uploader.url
+  end
+
   def recipe_params
     params.require(:recipe).permit(:title, :image, :image_cache, ingredients_attributes: [:id, :name, :quantity, :unit, :_destroy], instructions_attributes: [:id, :step_number, :description, :_destroy])
+  end
+
+  def update_ingredients_and_instructions(recipe, page)
+    page.search('.ingredient_row').each do |ingredient_row|
+      name = ingredient_row.at('.ingredient_name .name').text
+      quantity_text = ingredient_row.at('.ingredient_quantity.amount').text.strip
+      quantity, unit = Recipe.parse_quantity_and_unit(quantity_text)
+      updated_at = Time.current
+
+      existing_ingredient = recipe.ingredients.find_by(name: name)
+      if existing_ingredient
+        existing_ingredient.update(quantity:, unit:, updated_at:)
+      else
+        recipe.ingredients.build(name:, quantity:, unit:, updated_at:)
+      end
+    end
+
+    page.search('.step_text').each_with_index do |step_text, index|
+      description = step_text.text.strip
+      updated_at = Time.current
+
+      existing_instruction = recipe.instructions.find_by(step_number: index + 1)
+      if existing_instruction
+        existing_instruction.update(description: description, updated_at:)
+      else
+        recipe.instructions.build(step_number: index + 1, description:, updated_at:)
+      end
+    end
+  end
+
+  def set_ingredients_and_instructions(recipe, page)
+    page.search('.ingredient_row').each do |ingredient_row|
+      name = ingredient_row.at('.ingredient_name .name').text
+      quantity_text = ingredient_row.at('.ingredient_quantity.amount').text.strip
+      quantity, unit = Recipe.parse_quantity_and_unit(quantity_text)
+      recipe.ingredients.build(name:, quantity:, unit:)
+    end
+
+    page.search('.step_text').each_with_index do |step_text, index|
+      description = step_text.text.strip
+      recipe.instructions.build(step_number: index + 1, description:)
+    end
   end
 end

--- a/app/views/recipes/index.html.erb
+++ b/app/views/recipes/index.html.erb
@@ -21,7 +21,7 @@
                 <div class="recipe-text">
                   <div class="recipe-header">
                     <h3 class="recipe-title">
-                        <%= link_to recipe.title, "#" %>
+                        <%= link_to recipe.title, recipe_path(recipe) %>
                     </h3>
                   </div>
                   <div class="ingredients">

--- a/app/views/recipes/show.html.erb
+++ b/app/views/recipes/show.html.erb
@@ -1,0 +1,77 @@
+<% content_for(:title, t('.title')) %>
+<div class="container">
+  <div class="col d-flex justify-content-end align-items-center">
+    <span class="d-inline-block my-3">
+      <%= link_to t('.to_top_page'), root_path, class: "custom-link" %>
+    </span>
+  </div>
+  <h1 class="text-center mt-3"><%= t('.title') %></h1>
+  <div class="card mt-5 custom-card-manual-save mx-auto">
+    <div class="row my-5">
+      <div class="col-12 d-flex justify-content-center">
+        <h2><%= @recipe.title %></h2>
+      </div>
+    </div>
+    <div class="container px-5">
+      <div class="row">
+        <div class="col-6">
+          <div class="container px-3">
+            <%= image_tag @recipe.image.url, class: 'photo focus', alt: @recipe.title, width: 300, height: 200 if @recipe.image.present? %>
+            <div class="row my-5">
+              <div class="col-12">
+                <h3 class="subtitle me-4"><%= t('.ingredients') %></h3>
+                <div class="container pt-3 pe-5">
+                  <% @recipe.ingredients.each do |ingredient| %>
+                    <div class="row border-bottom border-dark">
+                      <div class="col-7 d-flex justify-content-start align-items-center">
+                        <%= ingredient.name %>
+                      </div>
+                      <div class="col-2 d-flex justify-content-end align-items-center">
+                        <%= ingredient.quantity %>
+                      </div>
+                      <div class="col-3 d-flex justify-content-start align-items-center">
+                        <%= ingredient.unit %><br>
+                      </div>
+                    </div>
+                  <% end %>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="col-6">
+          <div class="container px-3">
+            <div class="col-12">
+              <h3 class="subtitle me-4"><%= t('.instructions') %></h3>
+              <div class="container pt-3 pe-5">
+                <% @recipe.instructions.each do |instruction| %>
+                  <div class="row border-bottom border-dark mb-3">
+                    <div class="col-2 d-flex justify-content-center align-items-center">
+                      <%= instruction.step_number %>
+                    </div>
+                    <div class="col-10 d-flex justify-content-start align-items-center">
+                      <%= instruction.description %>
+                    </div>
+                  </div>
+                <% end %>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="container px-5 my-4">
+    <div class="row">
+      <div class="col-4 d-flex justify-content-end align-items-center">
+        <%= link_to t('.add_to_menu'), "#", class: "btn btn-add-menu btn-sm" %>
+      </div>
+      <div class="col-4 d-flex justify-content-center align-items-center">
+        <%= link_to t('.edit'), "#", class: "btn btn-recipe-edit btn-sm" %>
+      </div>
+      <div class="col-4 d-flex justify-content-start align-items-center">
+        <%= link_to t('.delete'), "#", method: :delete, data: { confirm: t('.confirm_delete') }, class: "btn btn-recipe-delete btn-sm" %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -124,6 +124,14 @@ ja:
       edit: 編集
       delete: 削除
       no_recipes_saved: 保存されているレシピはありません
+    show:
+      to_top_page: トップページへ
+      title: レシピ詳細
+      ingredients: 〜材料〜
+      instructions: 〜作り方〜
+      add_to_menu: メニュー表へ追加
+      edit: 編集
+      delete: 削除
   ingredient_fields:
     ingredient_name: 材料名
     quantity: 量


### PR DESCRIPTION
fix #21 
# 概要
レシピ詳細ページ作成
## 内容
- レシピの詳細ページを作成しました。
- ページにアクセスできるよう、コントローラーにshowアクションを設定しました。
- レシピ一覧ページのレシピタイトルを詳細ページへのリンクに設定しました。
- レシピの自動保存で画像が取得、保存できない問題を修正しました。
  - carrierwave導入に伴いurlのままimageカラムへ保存ができていなかったため、carrierwaveのremote_#{column}_url=(url)メソッドに、mechanizeで取得したurlを渡して保存するよう修正。