### PR TITLE
レシピの編集機能を実装

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -187,3 +187,19 @@ footer {
   text-align: center;
   letter-spacing: 5px;
 }
+
+.delete-checkbox input[type="checkbox"] {
+  width: 20px;
+  height: 20px;
+}
+
+.remove-button {
+  margin-left: 1em;
+}
+
+.step-number {
+  width: 40px;
+  height: 40px;
+  text-align: center;
+  margin-bottom: 4em;
+}

--- a/app/controllers/recipes_controller.rb
+++ b/app/controllers/recipes_controller.rb
@@ -76,6 +76,17 @@ class RecipesController < ApplicationController
     @recipe = current_user.recipes.find(params[:id])
   end
 
+  def update
+    @recipe = current_user.recipes.find(params[:id])
+    updated_params = process_instructions(recipe_params)
+    if @recipe.update(updated_params)
+      redirect_to recipe_path(@recipe), success: t('.update_success')
+    else
+      flash.now[:danger] = t('.update_failure')
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
   def create
     @recipe = current_user.recipes.new(recipe_params)
     if @recipe.save
@@ -101,6 +112,19 @@ class RecipesController < ApplicationController
 
   def recipe_params
     params.require(:recipe).permit(:title, :image, :image_cache, ingredients_attributes: [:id, :name, :quantity, :unit, :_destroy], instructions_attributes: [:id, :step_number, :description, :_destroy])
+  end
+
+  def process_instructions(params)
+    if params[:instructions_attributes].present?
+      current_step = 1
+      params[:instructions_attributes].each do |key, value|
+        if value[:_destroy] != '1'
+          value[:step_number] = current_step
+          current_step += 1
+        end
+      end
+    end
+    params
   end
 
   def update_ingredients_and_instructions(recipe, page)

--- a/app/controllers/recipes_controller.rb
+++ b/app/controllers/recipes_controller.rb
@@ -76,6 +76,16 @@ class RecipesController < ApplicationController
     @recipe = current_user.recipes.find(params[:id])
   end
 
+  def create
+    @recipe = current_user.recipes.new(recipe_params)
+    if @recipe.save
+      redirect_to root_path, success: t('.success')
+    else
+      flash.now[:danger] = t('.failure')
+      render :new, status: :unprocessable_entity
+    end
+  end
+
   def update
     @recipe = current_user.recipes.find(params[:id])
     updated_params = process_instructions(recipe_params)
@@ -84,16 +94,6 @@ class RecipesController < ApplicationController
     else
       flash.now[:danger] = t('.update_failure')
       render :edit, status: :unprocessable_entity
-    end
-  end
-
-  def create
-    @recipe = current_user.recipes.new(recipe_params)
-    if @recipe.save
-      redirect_to root_path, success: t('.success')
-    else
-      flash.now[:danger] = t('.failure')
-      render :new, status: :unprocessable_entity
     end
   end
 
@@ -117,7 +117,7 @@ class RecipesController < ApplicationController
   def process_instructions(params)
     if params[:instructions_attributes].present?
       current_step = 1
-      params[:instructions_attributes].each do |key, value|
+      params[:instructions_attributes].each_value do |value|
         if value[:_destroy] != '1'
           value[:step_number] = current_step
           current_step += 1

--- a/app/javascript/controllers/dynamic_form_controller.js
+++ b/app/javascript/controllers/dynamic_form_controller.js
@@ -31,6 +31,9 @@ export default class extends Controller {
       element.name = element.name.replace(/\[\d+\]/, `[${newIndex}]`);
     });
 
+    // 新しいフォームにはチェックボックスとラベルを追加しない
+    newForm.querySelectorAll('input[type="checkbox"]').forEach(el => el.closest('.delete-checkbox').remove());
+
     // 新しいフォームに削除ボタンを追加する
     const removeButton = this.createRemoveButton('ingredient');
     const formRow = newForm.querySelector('.row');
@@ -53,6 +56,9 @@ export default class extends Controller {
     newForm.querySelectorAll('[name]').forEach((element) => {
       element.name = element.name.replace(/\[\d+\]/, `[${newIndex}]`);
     });
+
+    // 新しいフォームにはチェックボックスとラベルを追加しない
+    newForm.querySelectorAll('input[type="checkbox"]').forEach(el => el.closest('.delete-checkbox').remove());
 
     // 新しいフォームに番号を付ける
     newForm.querySelector('input[name*="[step_number]"]').value = ++this.instructionCount;
@@ -92,7 +98,7 @@ export default class extends Controller {
     const removeButton = document.createElement('a');
     removeButton.href = '#';
     removeButton.textContent = 'x';
-    removeButton.className = `remove-${type} btn btn-danger`;
+    removeButton.className = `remove-${type} btn btn-danger remove-button`;
     removeButton.setAttribute('data-action', 'click->dynamic-form#removeForm');
     return removeButton;
   }

--- a/app/views/recipes/_ingredient_fields.html.erb
+++ b/app/views/recipes/_ingredient_fields.html.erb
@@ -1,7 +1,19 @@
 <div class="container ingredient-fields mb-2">
-  <div class="row">
-    <%= f.text_field :name, placeholder: t('ingredient_fields.ingredient_name'), required: true, style: 'width: 200px; height: 40px;' %>
-    <%= f.text_field :quantity, placeholder: t('ingredient_fields.quantity'), style: 'width: 80px; height: 40px;' %>
-    <%= f.text_field :unit, placeholder: t('ingredient_fields.unit'), required: true, style: 'width: 80px; height: 40px;' %>
+  <div class="row align-items-center">
+    <div class="col-auto pe-0">
+      <%= f.text_field :name, placeholder: t('ingredient_fields.ingredient_name'), required: true, style: 'width: 200px; height: 40px;' %>
+    </div>
+    <div class="col-auto px-0">
+      <%= f.text_field :quantity, placeholder: t('ingredient_fields.quantity'), style: 'width: 80px; height: 40px;' %>
+    </div>
+    <div class="col-auto px-0">
+      <%= f.text_field :unit, placeholder: t('ingredient_fields.unit'), required: true, style: 'width: 80px; height: 40px;' %>
+    </div>
+    <% unless f.object.new_record? %>
+      <div class="col-auto d-flex align-items-center delete-checkbox">
+        <%= f.check_box :_destroy %>
+        <%= f.label :_destroy, t('ingredient_fields._destroy'), class: 'ms-2' %>
+      </div>
+    <% end %>
   </div>
 </div>

--- a/app/views/recipes/_instruction_fields.html.erb
+++ b/app/views/recipes/_instruction_fields.html.erb
@@ -1,6 +1,16 @@
 <div class="container instruction-fields mb-2">
-  <div class="row">
-    <%= f.text_field :step_number, style: 'width: 40px; height: 40px;', value: f.object.step_number || 1, required: true %> 
-    <%= f.text_area :description, placeholder: t('instruction_fields.instruction_description'), required: true, style: 'width: 350px; height: 100px;' %>
+  <div class="row align-items-center">
+    <div class="col-auto pe-0">
+      <%= f.text_field :step_number, class: 'step-number', value: f.object.step_number || 1, required: true %> 
+    </div>
+    <div class="col-auto px-0">
+      <%= f.text_area :description, placeholder: t('instruction_fields.instruction_description'), required: true, style: 'width: 280px; height: 100px;' %>
+    </div>
+    <% unless f.object.new_record? %>
+      <div class="col-auto d-flex align-items-center delete-checkbox">
+        <%= f.check_box :_destroy %>
+        <%= f.label :_destroy, t('ingredient_fields._destroy'), class: 'ms-2' %>
+      </div>
+    <% end %>
   </div>
 </div>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -133,13 +133,17 @@ ja:
     edit:
       to_top_page: トップページへ
       title: レシピ編集
-      save: レシピを保存
+      save: レシピを更新
       add_ingredient: 材料のフォームを追加
       add_instruction: 作り方のフォームを追加
+    update:
+      update_success: レシピを更新しました
+      update_failure: レシピの更新に失敗しました
   ingredient_fields:
     ingredient_name: 材料名
     quantity: 量
     unit: 単位
+    _destroy: 削除
     remove: x
   instruction_fields:
     instruction_description: 作り方を入力


### PR DESCRIPTION
fix #42 
# 概要
保存したレシピの編集機能
## 内容
- レシピの編集機能を実装しました。
  - 既存のフォームを削除するチェックボックスを設置
  - 新たに追加するフォームにはフォーム削除のチェックボックスは表示しないように設定
  - 作り方のフォームで、既存のフォームに削除のチェックを入れ、新たにフォームを追加して入力後、更新したときに、自動的に手順番号が１から並ぶように設定
- 編集成功時と失敗時のフラッシュメッセージを設定しました。