### PR TITLE
メニュー表作成ページを作成

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -30,6 +30,9 @@ header {
   max-height: 100px; /* ロゴの高さを調整 */
   max-width: 100%;  /* 画像がコンテナを超えないように */
 }
+.nav-link.active {
+  color: #fff; /* 例: アクティブなリンクの色を白にする */
+}
 .custom-link {
   color: #4C4C4C;
   text-decoration: none; /* アンダーラインを消す場合 */
@@ -202,4 +205,17 @@ footer {
   height: 40px;
   text-align: center;
   margin-bottom: 4em;
+}
+
+.add-menu-checkbox input[type="checkbox"] {
+  width: 25px;
+  height: 25px;
+}
+
+.no-underline {
+  text-decoration: none;
+  color: rgba(var(--bs-link-color-rgb), var(--bs-link-opacity, 1)); /* 初期の色を設定 */
+}
+.no-underline:hover {
+  color: #61C359; /* ホバー時の色を設定（例として赤色） */
 }

--- a/app/controllers/menus_controller.rb
+++ b/app/controllers/menus_controller.rb
@@ -1,0 +1,8 @@
+class MenusController < ApplicationController
+  before_action :require_login
+
+  def new
+    @menu = Menu.new
+    @recipes = current_user.recipes
+  end
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -5,6 +5,6 @@ module ApplicationHelper
   end
 
   def active_if(path)
-    path == controller_path ? 'active' : ''
+    "active" if current_page?(path)
   end
 end

--- a/app/models/menu.rb
+++ b/app/models/menu.rb
@@ -1,0 +1,7 @@
+class Menu < ApplicationRecord
+  belongs_to :user
+  has_many :menu_recipes, dependent: :destroy
+  has_many :recipes, through: :menu_recipes
+
+  validates :title, presence: true
+end

--- a/app/models/menu_recipe.rb
+++ b/app/models/menu_recipe.rb
@@ -1,0 +1,4 @@
+class MenuRecipe < ApplicationRecord
+  belongs_to :menu
+  belongs_to :recipe
+end

--- a/app/models/recipe.rb
+++ b/app/models/recipe.rb
@@ -4,6 +4,8 @@ class Recipe < ApplicationRecord
   belongs_to :user
   has_many :ingredients, dependent: :destroy
   has_many :instructions, dependent: :destroy
+  has_many :menu_recipes, dependent: :destroy
+  has_many :menus, through: :menu_recipes
 
   accepts_nested_attributes_for :ingredients, reject_if: :all_blank, allow_destroy: true
   accepts_nested_attributes_for :instructions, reject_if: :all_blank, allow_destroy: true

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,6 @@
 class User < ApplicationRecord
   has_many :recipes, dependent: :destroy
+  has_many :menus, dependent: :destroy
 
   authenticates_with_sorcery!
 

--- a/app/views/menus/new.html.erb
+++ b/app/views/menus/new.html.erb
@@ -1,0 +1,43 @@
+<% content_for(:title, t('.title')) %>
+<div class="container">
+  <div class="col d-flex justify-content-end align-items-center">
+    <span class="d-inline-block my-3">
+      <%= link_to t('.to_top_page'), root_path, class: "custom-link" %>
+    </span>
+  </div>
+  <h1 class="text-center mt-3"><%= t('.title') %></h1>
+  <%= form_with(model: @menu, local: true) do |f| %>
+    <div class="row d-flex justify-content-center pt-5">
+      <div class="col-10 text-start">
+        <%= f.label :title, class: 'form-label', style: 'font-size: 30px;' %>
+        <%= f.text_field :title, class: 'form-label', placeholder: t('.menu_title'), style: 'width: 600px; height: 50px;' %>
+      </div>
+    </div>
+    <div class="container p-5">
+      <h4 class="pb-3"><%= t('.recipe_select') %></h4>
+      <div class="recipe-list mx-5">
+        <% @recipes.each do |recipe| %>
+          <div class="my-3 px-3 border-bottom border-dark" id="recipe_<%= recipe.id %>">
+            <div class="row">
+              <div class="col-1 d-flex justify-content-center align-items-center add-menu-checkbox">
+                <%= check_box_tag 'recipe_ids[]', recipe.id %>
+              </div>
+              <div class="col-11 d-flex justify-content-start align-items-center">
+                <div class="recipe-text">
+                  <div class="recipe-header">
+                    <h3 class="recipe-title">
+                      <%= link_to recipe.title, recipe_path(recipe), class: 'no-underline' %>
+                    </h3>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        <% end %>
+      </div>
+    </div>
+    <div class="d-grid gap-2 col-4 mx-auto my-5">
+      <%= f.submit t('.create'), class: "btn btn-primary" %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/recipes/index.html.erb
+++ b/app/views/recipes/index.html.erb
@@ -12,7 +12,7 @@
         <% @recipes.each do |recipe| %>
           <div class="recipe-preview my-3 px-3" id="recipe_<%= recipe.id %>">
             <div class="row">
-              <div class="col-2 d-flex justify-content-center align-items-center">
+              <div class="col-2 py-2 d-flex justify-content-center align-items-center">
                 <div class="recipe-image">
                   <%= image_tag recipe.image.url, class: 'photo focus', alt: recipe.title, width: 150, height: 100 if recipe.image.present? %>
                 </div>
@@ -21,7 +21,7 @@
                 <div class="recipe-text">
                   <div class="recipe-header">
                     <h3 class="recipe-title">
-                        <%= link_to recipe.title, recipe_path(recipe) %>
+                        <%= link_to recipe.title, recipe_path(recipe), class: 'no-underline' %>
                     </h3>
                   </div>
                   <div class="ingredients">
@@ -31,12 +31,7 @@
                   </div>
                 </div>
               </div>
-              <div class="col-3 my-3">
-                <div class="row mb-3">
-                  <div class="col-12 d-flex justify-content-center align-items-center">
-                    <%= link_to t('.add_to_menu'), "#", class: "btn btn-add-menu btn-sm" %>
-                  </div>
-                </div>
+              <div class="col-3 d-flex justify-content-center align-items-center">
                 <div class="row">
                   <div class="col-6 d-flex justify-content-center align-items-center">
                     <%= link_to t('.edit'), edit_recipe_path(recipe), class: "btn btn-recipe-edit btn-sm" %>

--- a/app/views/recipes/show.html.erb
+++ b/app/views/recipes/show.html.erb
@@ -62,15 +62,10 @@
     </div>
   </div>
   <div class="container px-5 my-4">
-    <div class="row">
-      <div class="col-4 d-flex justify-content-end align-items-center">
-        <%= link_to t('.add_to_menu'), "#", class: "btn btn-add-menu btn-sm" %>
-      </div>
+    <div class="row d-flex justify-content-center align-items-center">
       <div class="col-4 d-flex justify-content-center align-items-center">
-        <%= link_to t('.edit'), edit_recipe_path, class: "btn btn-recipe-edit btn-sm" %>
-      </div>
-      <div class="col-4 d-flex justify-content-start align-items-center">
-        <%= link_to t('.delete'), recipe_path(@recipe), data: { turbo_method: :delete, turbo_confirm: t('.confirm_delete') }, class: "btn btn-recipe-delete btn-sm" %>
+        <%= link_to t('.edit'), edit_recipe_path, class: "btn btn-recipe-edit btn-sm me-5" %>
+        <%= link_to t('.delete'), recipe_path(@recipe), data: { turbo_method: :delete, turbo_confirm: t('.confirm_delete') }, class: "btn btn-recipe-delete btn-sm ms-5" %>
       </div>
     </div>
   </div>

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -2,10 +2,10 @@
   <div class="container-fluid">
     <div class="collapse navbar-collapse" id="navbarNavAltMarkup">
       <div class="navbar-nav w-100 nav-justified">
-        <%= link_to t('navbar.recipe_search'), search_recipes_path, class: "nav-link #{active_if('search_recipes_path')}" %>
-        <%= link_to t('navbar.recipe_saving'), save_options_recipes_path, class: "nav-link #{active_if('recipes/save_optionsds')}" %>
-        <%= link_to t('navbar.recipe_list'), recipes_path, class: "nav-link #{active_if('/recipes')}" %>
-        <%= link_to t('navbar.menu_create'), "#", class: "nav-link #{active_if("#")}" %>
+        <%= link_to t('navbar.recipe_search'), search_recipes_path, class: "nav-link #{active_if(search_recipes_path)}" %>
+        <%= link_to t('navbar.recipe_saving'), save_options_recipes_path, class: "nav-link #{active_if(save_options_recipes_path)}" %>
+        <%= link_to t('navbar.recipe_list'), recipes_path, class: "nav-link #{active_if(recipes_path)}" %>
+        <%= link_to t('navbar.menu_create'), new_menu_path, class: "nav-link #{active_if(new_menu_path)}" %>
       </div>
     </div>
   </div>

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -28,3 +28,5 @@ ja:
       instructions:
         step_number: 手順の番号
         description: 作り方
+      menu:
+        title: メニュータイトル：

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -152,3 +152,10 @@ ja:
   instruction_fields:
     instruction_description: 作り方を入力
     remove: x
+  menus:
+    new:
+      to_top_page: トップページへ
+      title: メニュー候補レシピ一覧
+      menu_title: メニュー表のタイトルを入力
+      recipe_select: レシピを選択してください
+      create: メニュー表を作成

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,6 +22,7 @@ Rails.application.routes.draw do
       post 'fetch_recipe'  # レシピの自動取得アクション
     end
   end
+  resources :menus, only: %i[new create]
   get 'login', to: 'user_sessions#new'  # ログインページに対応するルート
   post 'login', to: 'user_sessions#create'
   delete 'logout', to: 'user_sessions#destroy'

--- a/db/migrate/20240722021123_create_menus.rb
+++ b/db/migrate/20240722021123_create_menus.rb
@@ -1,0 +1,10 @@
+class CreateMenus < ActiveRecord::Migration[7.1]
+  def change
+    create_table :menus do |t|
+      t.references :user, null: false, foreign_key: true
+      t.string :title
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20240722021317_create_menu_recipes.rb
+++ b/db/migrate/20240722021317_create_menu_recipes.rb
@@ -1,0 +1,10 @@
+class CreateMenuRecipes < ActiveRecord::Migration[7.1]
+  def change
+    create_table :menu_recipes do |t|
+      t.references :menu, null: false, foreign_key: true
+      t.references :recipe, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_07_17_051740) do
+ActiveRecord::Schema[7.1].define(version: 2024_07_22_021317) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -31,6 +31,23 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_17_051740) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["recipe_id"], name: "index_instructions_on_recipe_id"
+  end
+
+  create_table "menu_recipes", force: :cascade do |t|
+    t.bigint "menu_id", null: false
+    t.bigint "recipe_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["menu_id"], name: "index_menu_recipes_on_menu_id"
+    t.index ["recipe_id"], name: "index_menu_recipes_on_recipe_id"
+  end
+
+  create_table "menus", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.string "title"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_menus_on_user_id"
   end
 
   create_table "recipes", force: :cascade do |t|
@@ -62,5 +79,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_17_051740) do
 
   add_foreign_key "ingredients", "recipes"
   add_foreign_key "instructions", "recipes"
+  add_foreign_key "menu_recipes", "menus"
+  add_foreign_key "menu_recipes", "recipes"
+  add_foreign_key "menus", "users"
   add_foreign_key "recipes", "users"
 end

--- a/spec/factories/menu_recipes.rb
+++ b/spec/factories/menu_recipes.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :menu_recipe do
+    menu { nil }
+    recipe { nil }
+  end
+end

--- a/spec/factories/menus.rb
+++ b/spec/factories/menus.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :menu do
+    user { nil }
+    title { "MyString" }
+  end
+end

--- a/spec/models/menu_recipe_spec.rb
+++ b/spec/models/menu_recipe_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe MenuRecipe, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/menu_spec.rb
+++ b/spec/models/menu_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Menu, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
fix #23 
# 概要
メニュー表作成のページ作成
# 内容
- メニュー表作成ページを作成しました。
- ページには、保存したレシピが全て表示され、その中から選択する形としました。
- ページ作成に伴い、新たに以下のテーブル、カラム、コントローラーを生成しました。
  - menusテーブル（titleカラム）
  - menu_recipesテーブル（中間テーブル）
  - menus_controller.rb
- ルーティングの設定をしました。
- メニュー表作成ページの仕様変更により、レシピ一覧ページとレシピ詳細ページの「メニュー表へ追加」ボタンを削除しました。
- ナビゲーションバーのリンクのアクティブ化に関して、ヘルパーメソッドの内容と、ビューの内容を一部修正しました。