### PR TITLE
メニュー表作成機能を実装

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -219,3 +219,7 @@ footer {
 .no-underline:hover {
   color: #61C359; /* ホバー時の色を設定（例として赤色） */
 }
+
+.menu-preview {
+  background-color: #FFD982;
+}

--- a/app/controllers/menus_controller.rb
+++ b/app/controllers/menus_controller.rb
@@ -1,8 +1,84 @@
 class MenusController < ApplicationController
   before_action :require_login
 
+  def index
+    @menus = current_user.menus
+  end
+
+  def show
+    @menu = Menu.find(params[:id])
+    design = Design.find_by(name: '居酒屋風メニュー')
+    @layout = JSON.parse(design.layout)
+    @recipes = @menu.recipes
+  end
+
   def new
     @menu = Menu.new
     @recipes = current_user.recipes
+  end
+
+  def edit
+    @menu = current_user.menus.find(params[:id])
+    @recipes = current_user.recipes
+    @selected_recipes = @menu.recipes.pluck(:id)
+  end
+
+  def create
+    @menu = current_user.menus.new(menu_params)
+  
+    if @menu.save
+      params[:recipe_ids].each do |recipe_id|
+        MenuRecipe.create(menu_id: @menu.id, recipe_id: recipe_id)
+      end
+
+      default_design_id = 1
+      MenuDesign.create(menu_id: @menu.id, design_id: default_design_id)
+
+      redirect_to menu_path(@menu), success: t('.success')
+    else
+      flash.now[:danger] = t('.failure')
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  def update
+    @menu = current_user.menus.find(params[:id])
+
+    if @menu.update(menu_params)
+      # 新しいレシピのIDを取得
+      new_recipe_ids = params[:recipe_ids].reject(&:blank?).map(&:to_i)
+
+      # 現在のレシピのIDを取得
+      current_recipe_ids = @menu.recipes.pluck(:id)
+
+      # 新しく追加するレシピIDと削除するレシピIDを計算
+      recipes_to_add = new_recipe_ids - current_recipe_ids
+      recipes_to_remove = current_recipe_ids - new_recipe_ids
+
+      # 新しいレシピを追加
+      recipes_to_add.each do |recipe_id|
+        @menu.menu_recipes.create!(recipe_id: recipe_id)
+      end
+
+      # 古いレシピを削除
+      @menu.menu_recipes.where(recipe_id: recipes_to_remove).destroy_all
+
+      redirect_to menu_path(@menu), success: t('.success')
+    else
+      flash.now[:danger] = t('.failure')
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    menu = current_user.menus.find(params[:id])
+    menu.destroy!
+    redirect_to menus_path, success: t('.success')
+  end
+
+  private
+
+  def menu_params
+    params.require(:menu).permit(:title, recipe_ids: [])
   end
 end

--- a/app/controllers/menus_controller.rb
+++ b/app/controllers/menus_controller.rb
@@ -25,10 +25,10 @@ class MenusController < ApplicationController
 
   def create
     @menu = current_user.menus.new(menu_params)
-  
+
     if @menu.save
       params[:recipe_ids].each do |recipe_id|
-        MenuRecipe.create(menu_id: @menu.id, recipe_id: recipe_id)
+        MenuRecipe.create(menu_id: @menu.id, recipe_id:)
       end
 
       default_design_id = 1
@@ -46,7 +46,7 @@ class MenusController < ApplicationController
 
     if @menu.update(menu_params)
       # 新しいレシピのIDを取得
-      new_recipe_ids = params[:recipe_ids].reject(&:blank?).map(&:to_i)
+      new_recipe_ids = params[:recipe_ids].compact_blank.map(&:to_i)
 
       # 現在のレシピのIDを取得
       current_recipe_ids = @menu.recipes.pluck(:id)
@@ -57,7 +57,7 @@ class MenusController < ApplicationController
 
       # 新しいレシピを追加
       recipes_to_add.each do |recipe_id|
-        @menu.menu_recipes.create!(recipe_id: recipe_id)
+        @menu.menu_recipes.create!(recipe_id:)
       end
 
       # 古いレシピを削除

--- a/app/models/design.rb
+++ b/app/models/design.rb
@@ -1,4 +1,7 @@
 class Design < ApplicationRecord
+  has_many :menu_designs, dependent: :destroy
+  has_many :menus, through: :menu_designs
+
   validates :name, presence: true
   validates :layout, presence: true
 end

--- a/app/models/menu.rb
+++ b/app/models/menu.rb
@@ -2,6 +2,8 @@ class Menu < ApplicationRecord
   belongs_to :user
   has_many :menu_recipes, dependent: :destroy
   has_many :recipes, through: :menu_recipes
+  has_many :menu_designs, dependent: :destroy
+  has_many :designs, through: :menu_designs
 
-  validates :title, presence: true
+  validates :title, presence: true, uniqueness: true
 end

--- a/app/models/recipe.rb
+++ b/app/models/recipe.rb
@@ -10,7 +10,7 @@ class Recipe < ApplicationRecord
   accepts_nested_attributes_for :ingredients, reject_if: :all_blank, allow_destroy: true
   accepts_nested_attributes_for :instructions, reject_if: :all_blank, allow_destroy: true
 
-  validates :title, presence: true
+  validates :title, presence: true, uniqueness: true
   validates :source_url, format: { with: URI::DEFAULT_PARSER.make_regexp }, allow_nil: true
 
   def self.determine_source_site_name(url)

--- a/app/views/menus/edit.html.erb
+++ b/app/views/menus/edit.html.erb
@@ -21,7 +21,7 @@
             <div class="my-3 px-3 border-bottom border-dark" id="recipe_<%= recipe.id %>">
               <div class="row">
                 <div class="col-1 d-flex justify-content-center align-items-center add-menu-checkbox">
-                  <%= check_box_tag 'recipe_ids[]', recipe.id %>
+                  <%= check_box_tag 'recipe_ids[]', recipe.id, @selected_recipes.include?(recipe.id) %>
                 </div>
                 <div class="col-11 d-flex justify-content-start align-items-center">
                   <div class="recipe-text">
@@ -38,7 +38,7 @@
         </div>
       </div>
       <div class="d-grid gap-2 col-4 mx-auto my-5">
-        <%= f.submit t('.create'), class: "btn btn-primary" %>
+        <%= f.submit t('.update'), class: "btn btn-primary" %>
       </div>
     <% end %>
   <% else %>

--- a/app/views/menus/index.html.erb
+++ b/app/views/menus/index.html.erb
@@ -1,0 +1,42 @@
+<% content_for(:title, t('.title')) %>
+<div class="container">
+  <div class="col d-flex justify-content-end align-items-center">
+    <span class="d-inline-block my-3">
+      <%= link_to t('.to_top_page'), root_path, class: "custom-link" %>
+    </span>
+  </div>
+  <h1 class="text-center mt-3"><%= t('.title') %></h1>
+  <% if @menus.any? %>
+    <div class="container my-5">
+      <div class="menu-list">
+        <% @menus.each do |menu| %>
+          <div class="my-3 px-3" id="menu_<%= menu.id %>">
+            <div class="row menu-preview mx-5">
+              <div class="col-1"></div>
+              <div class="col-7 d-flex justify-content-start align-items-center">
+                <h3 class="menu-title">
+                    <%= link_to menu.title, menu_path(menu), class: 'no-underline' %>
+                </h3>
+              </div>
+              <div class="col-4 d-flex justify-content-center align-items-center">
+                <div class="row">
+                  <div class="col-6 d-flex justify-content-center align-items-center">
+                    <%= link_to t('.edit'), edit_menu_path(menu), class: "btn btn-recipe-edit btn-sm" %>
+                  </div>
+                  <div class="col-6 d-flex justify-content-start align-items-center">
+                    <%= link_to t('.delete'), menu_path(menu), data: { turbo_method: :delete, turbo_confirm: t('.confirm_delete') }, class: "btn btn-recipe-delete btn-sm" %>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        <% end %>
+      </div>
+    </div>
+  <% else %>
+    <div class="alert alert-info text-center">
+      <%= t('.no_menus_saved') %>
+    </div>
+  <% end %>
+  </div>
+</div>

--- a/app/views/menus/show.html.erb
+++ b/app/views/menus/show.html.erb
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title><%= @menu.title %></title>
+  <style>
+    <% if @layout['font-face'] %>
+      @font-face {
+        font-family: <%= raw "'#{@layout['font-face']['font-family']}'" %>;
+        src: <%= raw @layout['font-face']['src'] %>;
+        font-weight: <%= @layout['font-face']['font-weight'] %>;
+        font-style: <%= @layout['font-face']['font-style'] %>;
+      }
+    <% end %>
+
+    <% @layout.each do |key, properties| %>
+      <% if key == 'body' %>
+        .menulist-container {
+          <% properties.each do |prop, value| %>
+            <%= prop.gsub('_', '-') %>: <%= raw(value.is_a?(Array) ? value.map { |v| "'#{v}'" }.join(', ') : value) %>;
+          <% end %>
+        }
+      <% elsif key != 'font-face' %>
+        .menulist-container .<%= key %> {
+          <% properties.each do |prop, value| %>
+            <%= prop.gsub('_', '-') %>: <%= raw(value.is_a?(Array) ? value.map { |v| "'#{v}'" }.join(', ') : value) %>;
+          <% end %>
+        }
+      <% end %>
+    <% end %>
+  </style>
+</head>
+<body>
+<div class="container">
+  <div class="col d-flex justify-content-end align-items-center">
+    <span class="d-inline-block my-3">
+      <%= link_to t('.to_top_page'), root_path, class: "custom-link" %>
+    </span>
+  </div>
+  <h1 class="text-center my-5"><%= t('.title') %></h1>
+  <div class="menulist-container">
+    <div class="menu-container">
+      <div class="menu-title"><span class="title-under"><%= @menu.title %></span></div>
+      <div class="menu-recipes">
+        <% @recipes.each do |recipe| %>
+          <div class="recipe-title">
+            <span class="under"><%= recipe.title %></span>
+          </div>
+        <% end %>
+      </div>
+    </div>
+    <div class="illustrations-container">
+      <div class="illustration-curry"></div>
+      <div class="illustration-onigiri"></div>
+    </div>
+  </div>
+  <div class="container px-5 my-4">
+    <div class="row d-flex justify-content-center align-items-center">
+      <div class="col-8 d-flex justify-content-center align-items-center">
+        <%= link_to t('.edit'), edit_menu_path, class: "btn btn-recipe-edit btn-sm me-5" %>
+        <%= link_to t('.delete'), menu_path(@menu), data: { turbo_method: :delete, turbo_confirm: t('.confirm_delete') }, class: "btn btn-recipe-delete btn-sm ms-5" %>
+      </div>
+    </div>
+  </div>
+</div>
+</body>
+</html>

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -6,6 +6,7 @@
         <%= link_to t('navbar.recipe_saving'), save_options_recipes_path, class: "nav-link #{active_if(save_options_recipes_path)}" %>
         <%= link_to t('navbar.recipe_list'), recipes_path, class: "nav-link #{active_if(recipes_path)}" %>
         <%= link_to t('navbar.menu_create'), new_menu_path, class: "nav-link #{active_if(new_menu_path)}" %>
+        <%= link_to t('navbar.menu_list'), menus_path, class: "nav-link #{active_if(menus_path)}" %>
       </div>
     </div>
   </div>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -14,7 +14,8 @@ ja:
     recipe_search: レシピ検索
     recipe_saving: レシピ保存
     recipe_list: レシピ一覧
-    menu_create: メニュー作成
+    menu_create: メニュー表作成
+    menu_list: メニュー表一覧
   footer:
     inquiry: お問い合わせ
     terms_of_use: 利用規約
@@ -118,7 +119,6 @@ ja:
     index:
       to_top_page: トップページへ
       title: レシピ一覧
-      add_to_menu: メニュー表へ追加
       edit: 編集
       delete: 削除
       no_recipes_saved: 保存されているレシピはありません
@@ -128,7 +128,6 @@ ja:
       title: レシピ詳細
       ingredients: 〜材料〜
       instructions: 〜作り方〜
-      add_to_menu: メニュー表へ追加
       edit: 編集
       delete: 削除
       confirm_delete: このレシピを削除しますか？
@@ -159,3 +158,30 @@ ja:
       menu_title: メニュー表のタイトルを入力
       recipe_select: レシピを選択してください
       create: メニュー表を作成
+      no_recipes_saved: メニューに追加できるレシピがありません
+    create:
+      success: メニューを作成しました
+      failure: メニューの作成に失敗しました
+    show:
+      to_top_page: トップページへ
+      title: メニュー表確認画面
+      edit: メニュー表の編集
+      delete: メニュー表を削除
+      confirm_delete: このメニュー表を削除しますか？
+    index:
+      to_top_page: トップページへ
+      title: メニュー表一覧
+      edit: 編集
+      delete: 削除
+      confirm_delete: このメニュー表を削除しますか？
+    edit:
+      to_top_page: トップページへ
+      title: メニュー表編集
+      recipe_select: レシピを選択してください
+      update: メニュー表を更新
+      no_recipes_saved: メニュー表にレシピがありません
+    update:
+      success: メニュー表を更新しました
+      failure: メニュー表の更新に失敗しました
+    destroy:
+      success: メニュー表を削除しました

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,7 +22,7 @@ Rails.application.routes.draw do
       post 'fetch_recipe'  # レシピの自動取得アクション
     end
   end
-  resources :menus, only: %i[new create]
+  resources :menus
   get 'login', to: 'user_sessions#new'  # ログインページに対応するルート
   post 'login', to: 'user_sessions#create'
   delete 'logout', to: 'user_sessions#destroy'

--- a/db/migrate/20240724081804_add_unique_index_to_menus.rb
+++ b/db/migrate/20240724081804_add_unique_index_to_menus.rb
@@ -1,0 +1,5 @@
+class AddUniqueIndexToMenus < ActiveRecord::Migration[7.1]
+  def change
+    add_index :menus, :title, unique: true
+  end
+end

--- a/db/migrate/20240724081912_add_unique_index_to_recipes.rb
+++ b/db/migrate/20240724081912_add_unique_index_to_recipes.rb
@@ -1,0 +1,5 @@
+class AddUniqueIndexToRecipes < ActiveRecord::Migration[7.1]
+  def change
+    add_index :recipes, :title, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_07_23_080917) do
+ActiveRecord::Schema[7.1].define(version: 2024_07_24_081912) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -63,6 +63,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_23_080917) do
     t.string "title"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["title"], name: "index_menus_on_title", unique: true
     t.index ["user_id"], name: "index_menus_on_user_id"
   end
 
@@ -75,6 +76,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_23_080917) do
     t.datetime "scraped_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["title"], name: "index_recipes_on_title", unique: true
     t.index ["user_id"], name: "index_recipes_on_user_id"
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -3,81 +3,83 @@
 # The data can then be loaded with the bin/rails db:seed command (or created alongside the database with db:setup).
 #
 izakaya_layout = {
-  "fontFace": {
-    "fontFamily": "MyCustomFont",
-    "src": "url('/assets/Ounen-mouhitsu.otf') format('opentype')",
-    "fontWeight": "normal",
-    "fontStyle": "normal"
+  "font-face" => {
+    "font-family" => "MyCustomFont",
+    "src" => "url('/assets/Ounen-mouhitsu.otf') format('opentype')",
+    "font-weight" => "normal",
+    "font-style" => "normal"
   },
-  "body": {
-    "backgroundImage": "url('/assets/izakaya_image_background.png')",
-    "fontFamily": ["MyCustomFont", "凸版文久見出し明朝"],
-    "color": "#000000"
+  "body" => {
+    "background-image" => "url('/assets/izakaya_image_background.png')",
+    "font-family" => ["MyCustomFont", "凸版文久見出し明朝"],
+    "color" => "#000000"
   },
-  "menuContainer": {
-    "width": "100%",
-    "maxWidth": "800px",
-    "margin": "0 auto",
-    "padding": "50px 50px"
+  "menu-container" => {
+    "width" => "100%",
+    "max-width" => "800px",
+    "margin" => "0 auto",
+    "padding" => "50px 50px"
   },
-  "titleUnder": {
-    "backgroundImage": "url('/assets/izakaya_image_title.png')",
-    "backgroundRepeat": "no-repeat",
-    "backgroundPosition": "center",
-    "backgroundSize": "200% 180%",
-    "paddingBottom": "1.7em",
-    "title": "{menu_title}"  # プレースホルダー
+  "menu-title" => {
+    "text-align" => "center",
+    "font-size" => "100px",
+    "margin-bottom" => "50px"
   },
-  "menuTitle": {
-    "textAlign": "center",
-    "fontSize": "100px",
-    "marginBottom": "50px"
+  "title-under" => {
+    "background-image" => "url('/assets/izakaya_image_title.png')",
+    "background-repeat" => "no-repeat",
+    "background-position" => "center",
+    "background-size" => "200% 180%",
+    "padding-bottom" => "1.7em"
   },
-  "menuRecipes": {
-    "fontSize": "55px",
-    "padding": "30px 0"
+  "menu-recipes" => {
+    "font-size" => "55px",
+    "padding" => "30px 0"
   },
-  "recipeTitle": {
-    "marginTop": "50px",
-    "recipe_titles": ["{recipe_titles}"]  # プレースホルダー
+  "recipe-title" => {
+    "margin-top" => "50px"
   },
-  "under": {
-    "backgroundImage": "url('/assets/izakaya_image_underbar.png')",
-    "backgroundRepeat": "no-repeat",
-    "backgroundPosition": "center",
-    "backgroundSize": "300% 300%",
-    "paddingBottom": "0.7em"
+  "under" => {
+    "background-image" => "url('/assets/izakaya_image_underbar.png')",
+    "background-repeat" => "no-repeat",
+    "background-position" => "center",
+    "background-size" => "300% 300%",
+    "padding-bottom" => "0.7em"
   },
-  "illustrationsContainer": {
-    "display": "flex",
-    "justifyContent": "space-between",
-    "padding": "0 50px",
-    "marginBottom": "50px"
+  "illustrations-container" => {
+    "display" => "flex",
+    "justify-content" => "space-between",
+    "padding" => "0 50px",
+    "margin-bottom" => "50px"
   },
-  "illustrationCurry": {
-    "height": "200px",
-    "width": "400px",
-    "backgroundSize": "180% 250%",
-    "backgroundImage": "url('/assets/izakaya_image_curry.png')",
-    "backgroundRepeat": "no-repeat",
-    "backgroundPosition": "center",
-    "marginTop": "1em",
-    "transform": "rotate(5deg)"
+  "illustration-curry" => {
+    "height" => "200px",
+    "width" => "400px",
+    "background-size" => "180% 250%",
+    "background-image" => "url('/assets/izakaya_image_curry.png')",
+    "background-repeat" => "no-repeat",
+    "background-position" => "center",
+    "margin-top" => "1em",
+    "transform" => "rotate(5deg)"
   },
-  "illustrationOnigiri": {
-    "height": "200px",
-    "width": "400px",
-    "backgroundSize": "180% 250%",
-    "backgroundImage": "url('/assets/izakaya_image_onigiri.png')",
-    "backgroundRepeat": "no-repeat",
-    "backgroundPosition": "center",
-    "marginTop": "1em",
-    "transform": "rotate(-10deg)"
+  "illustration-onigiri" => {
+    "height" => "200px",
+    "width" => "400px",
+    "background-size" => "180% 250%",
+    "background-image" => "url('/assets/izakaya_image_onigiri.png')",
+    "background-repeat" => "no-repeat",
+    "background-position" => "center",
+    "margin-top" => "1em",
+    "transform" => "rotate(-10deg)"
   }
 }
 
-# デザインデータをデータベースに保存
-Design.create!(
-  name: '居酒屋風メニュー',
-  layout: izakaya_layout.to_json
-)
+design = Design.find_by(name: '居酒屋風メニュー')
+if design
+  design.update!(layout: izakaya_layout.to_json)
+else
+  Design.create!(
+    name: '居酒屋風メニュー',
+    layout: izakaya_layout.to_json
+  )
+end


### PR DESCRIPTION
fix #83 ,
fix #84 ,
fix #24 
# 概要
メニュー表の作成機能実装準備
メニュー表作成機能の実装
メニュー表確認ページ作成
# 内容
- メニュー表作成機能を実装しました。
- 作成したメニュー表を確認できるページ（メニュー表確認ページ）を作成しました。
- 作成したメニュー表を一覧で確認できるページ（メニュー表一覧）を作成しました。
- 作成したメニュー表の編集機能と削除機能を実装しました。
- 上記ページ、機能の実装に伴い、menus_controllerと、ルーティングの設定を追加、更新しました。
- メニュー表のデザインデータを修正しました。
- design、menu、recipieのモデルファイルにアソシエーションを追加しました。