### PR TITLE
メニュー表関連のテストコードを作成

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -223,3 +223,7 @@ footer {
 .menu-preview {
   background-color: #FFD982;
 }
+
+.field_with_errors {
+  display: contents;
+}

--- a/app/controllers/recipes_controller.rb
+++ b/app/controllers/recipes_controller.rb
@@ -81,6 +81,8 @@ class RecipesController < ApplicationController
     if @recipe.save
       redirect_to recipe_path(@recipe), success: t('.success')
     else
+      @recipe.ingredients.build if @recipe.ingredients.empty?
+      @recipe.instructions.build if @recipe.instructions.empty?
       flash.now[:danger] = t('.failure')
       render :new, status: :unprocessable_entity
     end

--- a/app/javascript/controllers/dynamic_form_controller.js
+++ b/app/javascript/controllers/dynamic_form_controller.js
@@ -9,6 +9,15 @@ export default class extends Controller {
     // カウンターを初期フォームの数からスタートさせる
     this.instructionCount = this.initialFormCount;
 
+    // ページのモード（new または edit）を取得
+    const mode = this.element.dataset.mode;
+
+    if (mode === 'new') {
+      this.addRemoveButtonsToNewFormsForNew();
+    } else if (mode === 'edit') {
+      this.addRemoveButtonsToNewFormsForEdit();
+    }
+
     // 削除ボタンがクリックされたときのイベントリスナーを追加
     this.element.addEventListener('click', (event) => {
       if (event.target.classList.contains('remove-instruction') || event.target.classList.contains('remove-ingredient')) {
@@ -38,6 +47,9 @@ export default class extends Controller {
     const removeButton = this.createRemoveButton('ingredient');
     const formRow = newForm.querySelector('.row');
     formRow.appendChild(removeButton);
+
+     // 新しいフォームに `data-new-form="true"` を設定
+    newForm.setAttribute('data-new-form', 'true');
 
     const addIngredientLink = this.element.querySelector('.add-ingredient');
     this.nestedFormsTarget.insertBefore(newForm, addIngredientLink);
@@ -74,7 +86,7 @@ export default class extends Controller {
   removeForm(event) {
     event.preventDefault();
     const formContainer = event.target.closest('.instruction-fields, .ingredient-fields');
-    if (formContainer && formContainer.dataset.newForm !== 'true') {
+    if (formContainer) {
       formContainer.remove();
       this.recalculateStepNumbers();
     }
@@ -101,5 +113,31 @@ export default class extends Controller {
     removeButton.className = `remove-${type} btn btn-danger remove-button`;
     removeButton.setAttribute('data-action', 'click->dynamic-form#removeForm');
     return removeButton;
+  }
+
+  addRemoveButtonsToNewFormsForNew() {
+    const newForms = this.nestedFormsTarget.querySelectorAll('[data-new-form="true"]');
+    newForms.forEach((form, index) => {
+      if (index > 0) { // 最初のフォームには削除ボタンを追加しない
+        if (!form.querySelector('.remove-button')) {
+          const type = form.classList.contains('ingredient-fields') ? 'ingredient' : 'instruction';
+          const removeButton = this.createRemoveButton(type);
+          const formRow = form.querySelector('.row');
+          formRow.appendChild(removeButton);
+        }
+      }
+    });
+  }
+
+  addRemoveButtonsToNewFormsForEdit() {
+    const newForms = this.nestedFormsTarget.querySelectorAll('[data-new-form="true"]');
+    newForms.forEach((form) => {
+      if (!form.querySelector('.remove-button')) {
+        const type = form.classList.contains('ingredient-fields') ? 'ingredient' : 'instruction';
+        const removeButton = this.createRemoveButton(type);
+        const formRow = form.querySelector('.row');
+        formRow.appendChild(removeButton);
+      }
+    });
   }
 }

--- a/app/models/menu.rb
+++ b/app/models/menu.rb
@@ -6,4 +6,11 @@ class Menu < ApplicationRecord
   has_many :designs, through: :menu_designs
 
   validates :title, presence: true, uniqueness: true
+  validate :must_have_at_least_one_recipe
+
+  private
+
+  def must_have_at_least_one_recipe
+    errors.add(:recipe_ids, "must be present") if recipe_ids.blank?
+  end
 end

--- a/app/models/recipe.rb
+++ b/app/models/recipe.rb
@@ -7,8 +7,8 @@ class Recipe < ApplicationRecord
   has_many :menu_recipes, dependent: :destroy
   has_many :menus, through: :menu_recipes
 
-  accepts_nested_attributes_for :ingredients, reject_if: :all_blank, allow_destroy: true
-  accepts_nested_attributes_for :instructions, reject_if: :all_blank, allow_destroy: true
+  accepts_nested_attributes_for :ingredients, allow_destroy: true
+  accepts_nested_attributes_for :instructions, allow_destroy: true
 
   validates :title, presence: true, uniqueness: true
   validates :source_url, format: { with: URI::DEFAULT_PARSER.make_regexp }, allow_nil: true

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,7 +7,8 @@ class User < ApplicationRecord
   attr_accessor :current_password
 
   validates :name, presence: true, length: { maximum: 255 }
-  validates :email, presence: true, format: { with: URI::MailTo::EMAIL_REGEXP }, uniqueness: true
+  validates :email, presence: true
+  validates :email, format: { with: URI::MailTo::EMAIL_REGEXP }, uniqueness: true, if: -> { email.present? }
   validates :password, length: { minimum: 4 }, if: -> { new_record? || changes[:crypted_password] }
   validates :password, confirmation: true, if: -> { new_record? || changes[:crypted_password] }
   validates :password_confirmation, presence: true, if: -> { new_record? || changes[:crypted_password] }

--- a/app/views/menus/edit.html.erb
+++ b/app/views/menus/edit.html.erb
@@ -7,7 +7,8 @@
   </div>
   <h1 class="text-center mt-3"><%= t('.title') %></h1>
   <% if @recipes.present? %>
-    <%= form_with(model: @menu, local: true) do |f| %>
+    <%= form_with model: @menu do |f| %>
+    <%= render 'shared/error_messages', object: f.object %>
       <div class="row d-flex justify-content-center pt-5">
         <div class="col-10 text-start">
           <%= f.label :title, class: 'form-label', style: 'font-size: 30px;' %>
@@ -21,7 +22,7 @@
             <div class="my-3 px-3 border-bottom border-dark" id="recipe_<%= recipe.id %>">
               <div class="row">
                 <div class="col-1 d-flex justify-content-center align-items-center add-menu-checkbox">
-                  <%= check_box_tag 'recipe_ids[]', recipe.id, @selected_recipes.include?(recipe.id) %>
+                  <%= check_box_tag 'menu[recipe_ids][]', recipe.id, @selected_recipes.include?(recipe.id) %>
                 </div>
                 <div class="col-11 d-flex justify-content-start align-items-center">
                   <div class="recipe-text">

--- a/app/views/menus/new.html.erb
+++ b/app/views/menus/new.html.erb
@@ -7,7 +7,8 @@
   </div>
   <h1 class="text-center mt-3"><%= t('.title') %></h1>
   <% if @recipes.present? %>
-    <%= form_with(model: @menu, local: true) do |f| %>
+    <%= form_with model: @menu do |f| %>
+    <%= render 'shared/error_messages', object: f.object %>
       <div class="row d-flex justify-content-center pt-5">
         <div class="col-10 text-start">
           <%= f.label :title, class: 'form-label', style: 'font-size: 30px;' %>
@@ -21,7 +22,7 @@
             <div class="my-3 px-3 border-bottom border-dark" id="recipe_<%= recipe.id %>">
               <div class="row">
                 <div class="col-1 d-flex justify-content-center align-items-center add-menu-checkbox">
-                  <%= check_box_tag 'recipe_ids[]', recipe.id %>
+                  <%= check_box_tag 'menu[recipe_ids][]', recipe.id %>
                 </div>
                 <div class="col-11 d-flex justify-content-start align-items-center">
                   <div class="recipe-text">

--- a/app/views/profiles/edit_email.html.erb
+++ b/app/views/profiles/edit_email.html.erb
@@ -18,7 +18,7 @@
           </div>
           <div class="mb-3">
             <%= f.label :new_email, class: "form-label" %>
-            <%= f.text_field :email, class: "form-control", id: "new_email", value: nil, required: true %>
+            <%= f.text_field :email, class: "form-control", id: "new_email", value: nil %>
           </div>
         </div>
       </div>

--- a/app/views/profiles/edit_password.html.erb
+++ b/app/views/profiles/edit_password.html.erb
@@ -14,15 +14,15 @@
         <div class="col-md-8">
           <div class="mb-3">
             <%= f.label :current_password, class: 'form-label' %>
-            <%= f.password_field :current_password, class: "form-control", required: true %>
+            <%= f.password_field :current_password, class: "form-control" %>
           </div>
           <div class="mb-3">
             <%= f.label :new_password, class: "form-label" %>
-            <%= f.password_field :password, class: "form-control", required: true %>
+            <%= f.password_field :password, class: "form-control" %>
           </div>
           <div class="mb-3">
             <%= f.label :new_password_confirmation, class: "form-label" %>
-            <%= f.password_field :password_confirmation, class: "form-control", required: true %>
+            <%= f.password_field :password_confirmation, class: "form-control" %>
           </div>
         </div>
       </div>

--- a/app/views/profiles/edit_username.html.erb
+++ b/app/views/profiles/edit_username.html.erb
@@ -18,7 +18,7 @@
           </div>
           <div class="mb-3">
             <%= f.label :new_name, class: "form-label" %>
-            <%= f.text_field :name, class: "form-control", id: "new_name", value: nil, required: true %>
+            <%= f.text_field :name, class: "form-control", id: "new_name", value: nil %>
           </div>
         </div>
       </div>

--- a/app/views/recipes/_ingredient_fields.html.erb
+++ b/app/views/recipes/_ingredient_fields.html.erb
@@ -1,13 +1,13 @@
-<div class="container ingredient-fields mb-2">
+<div class="container ingredient-fields mb-2" data-new-form="<%= f.object.new_record? ? 'true' : 'false' %>">
   <div class="row align-items-center">
     <div class="col-auto pe-0">
-      <%= f.text_field :name, placeholder: t('ingredient_fields.ingredient_name'), required: true, style: 'width: 200px; height: 40px;' %>
+      <%= f.text_field :name, placeholder: t('ingredient_fields.ingredient_name'), style: 'width: 200px; height: 40px;' %>
     </div>
     <div class="col-auto px-0">
       <%= f.text_field :quantity, placeholder: t('ingredient_fields.quantity'), style: 'width: 80px; height: 40px;' %>
     </div>
     <div class="col-auto px-0">
-      <%= f.text_field :unit, placeholder: t('ingredient_fields.unit'), required: true, style: 'width: 80px; height: 40px;' %>
+      <%= f.text_field :unit, placeholder: t('ingredient_fields.unit'), style: 'width: 80px; height: 40px;' %>
     </div>
     <% unless f.object.new_record? %>
       <div class="col-auto d-flex align-items-center delete-checkbox">

--- a/app/views/recipes/_instruction_fields.html.erb
+++ b/app/views/recipes/_instruction_fields.html.erb
@@ -1,10 +1,10 @@
-<div class="container instruction-fields mb-2">
+<div class="container instruction-fields mb-2" data-new-form="<%= f.object.new_record? ? 'true' : 'false' %>">
   <div class="row align-items-center">
     <div class="col-auto pe-0">
-      <%= f.text_field :step_number, class: 'step-number', value: f.object.step_number || 1, required: true %> 
+      <%= f.text_field :step_number, class: 'step-number', value: f.object.step_number || 1 %> 
     </div>
     <div class="col-auto px-0">
-      <%= f.text_area :description, placeholder: t('instruction_fields.instruction_description'), required: true, style: 'width: 280px; height: 100px;' %>
+      <%= f.text_area :description, placeholder: t('instruction_fields.instruction_description'), style: 'width: 280px; height: 100px;' %>
     </div>
     <% unless f.object.new_record? %>
       <div class="col-auto d-flex align-items-center delete-checkbox">

--- a/app/views/recipes/edit.html.erb
+++ b/app/views/recipes/edit.html.erb
@@ -6,7 +6,7 @@
     </span>
   </div>
   <h1 class="text-center mt-3"><%= t('.title') %></h1>
-  <%= form_with model: @recipe, local: true do |f| %>
+  <%= form_with model: @recipe do |f| %>
   <%= render 'shared/error_messages', object: f.object %>
     <div class="card mt-5 custom-card-manual-save mx-auto">
       <div class="row mt-5 d-flex justify-content-center">
@@ -18,7 +18,7 @@
       <div class="container py-2 my-5">
         <div class="row">
           <div class="col-6 d-flex justify-content-center">
-            <div id="ingredients-form" data-controller="dynamic-form" data-dynamic-form-target="nestedForms">
+            <div id="ingredients-form" data-controller="dynamic-form" data-mode="edit" data-dynamic-form-target="nestedForms">
               <%= f.label :ingredients, class: 'form-label' %>
               <%= f.fields_for :ingredients do |ingredient_fields| %>
                 <%= render 'ingredient_fields', f: ingredient_fields %>
@@ -27,7 +27,7 @@
             </div>
           </div>
           <div class="col-6 d-flex justify-content-center">
-            <div id="instructions-form" data-controller="dynamic-form" data-dynamic-form-target="nestedForms">
+            <div id="instructions-form" data-controller="dynamic-form" data-mode="edit" data-dynamic-form-target="nestedForms">
               <%= f.label :instructions, class: 'form-label'%>
               <%= f.fields_for :instructions  do |instruction_fields| %>
                 <%= render 'instruction_fields', f: instruction_fields %>

--- a/app/views/recipes/index.html.erb
+++ b/app/views/recipes/index.html.erb
@@ -14,7 +14,11 @@
             <div class="row">
               <div class="col-2 py-2 d-flex justify-content-center align-items-center">
                 <div class="recipe-image">
-                  <%= image_tag recipe.image.url, class: 'photo focus', alt: recipe.title, width: 150, height: 100 if recipe.image.present? %>
+                <% if recipe.image.present? %>
+                <%= image_tag recipe.image.url, class: 'photo focus', alt: recipe.title, width: 150, height: 100 %>
+              <% else %>
+                <%= image_tag 'default_image.png', class: 'photo focus', alt: 'サンプル画像', width: 150, height: 100 %>
+              <% end %>
                 </div>
               </div>
               <div class="col-7 d-flex justify-content-start align-items-center">

--- a/app/views/recipes/new.html.erb
+++ b/app/views/recipes/new.html.erb
@@ -6,7 +6,7 @@
     </span>
   </div>
   <h1 class="text-center mt-3"><%= t('.title') %></h1>
-  <%= form_with model: @recipe, local: true do |f| %>
+  <%= form_with model: @recipe do |f| %>
   <%= render 'shared/error_messages', object: f.object %>
     <div class="card mt-5 custom-card-manual-save mx-auto">
       <div class="row mt-5 d-flex justify-content-center">
@@ -18,7 +18,7 @@
       <div class="container py-2 my-5">
         <div class="row">
           <div class="col-6 d-flex justify-content-center">
-            <div id="ingredients-form" data-controller="dynamic-form" data-dynamic-form-target="nestedForms">
+            <div id="ingredients-form" data-controller="dynamic-form" data-mode="new" data-dynamic-form-target="nestedForms">
               <%= f.label :ingredients, class: 'form-label' %>
               <%= f.fields_for :ingredients do |ingredient_fields| %>
                 <%= render 'ingredient_fields', f: ingredient_fields %>
@@ -27,7 +27,7 @@
             </div>
           </div>
           <div class="col-6 d-flex justify-content-center">
-            <div id="instructions-form" data-controller="dynamic-form" data-dynamic-form-target="nestedForms">
+            <div id="instructions-form" data-controller="dynamic-form" data-mode="new" data-dynamic-form-target="nestedForms">
               <%= f.label :instructions, class: 'form-label'%>
               <%= f.fields_for :instructions  do |instruction_fields| %>
                 <%= render 'instruction_fields', f: instruction_fields %>

--- a/app/views/recipes/show.html.erb
+++ b/app/views/recipes/show.html.erb
@@ -16,7 +16,11 @@
       <div class="row">
         <div class="col-6">
           <div class="container px-3">
-            <%= image_tag @recipe.image.url, class: 'photo focus', alt: @recipe.title, width: 300, height: 200 if @recipe.image.present? %>
+          <% if @recipe.image.present? %>
+          <%= image_tag @recipe.image.url, class: 'photo focus', alt: @recipe.title, width: 300, height: 200 %>
+        <% else %>
+          <%= image_tag 'default_image.png', class: 'photo focus', alt: 'サンプル画像', width: 300, height: 200 %>
+        <% end %>
             <div class="row my-5">
               <div class="col-12">
                 <h3 class="subtitle me-4"><%= t('.ingredients') %></h3>

--- a/app/views/user_sessions/new.html.erb
+++ b/app/views/user_sessions/new.html.erb
@@ -13,11 +13,11 @@
           <%= form_with url: login_path do |f| %>
             <div class="mb-3">
               <%= f.label :email, class: "form-label" %>
-              <%= f.email_field :email, class: "form-control", required: true %>
+              <%= f.email_field :email, class: "form-control" %>
             </div>
             <div class="mb-5">
               <%= f.label :password, class: "form-label" %>
-              <%= f.password_field :password, class: "form-control", required: true %>
+              <%= f.password_field :password, class: "form-control" %>
             </div>
             <div class="d-grid gap-2 col-6 mx-auto">
               <%= f.submit t('.login'), class: "btn btn-primary" %>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -6,34 +6,34 @@
     </span>
   </div>
   <h1 class="text-center mt-3"><%= t('.title') %></h1>
-  <div class="card mt-5 custom-card-width">
-    <div class="container py-2 my-5">
-      <div class="row my-auto">
-        <div class="col-md-10 col-lg-8 mx-auto">
-          <%= form_with model: @user do |f| %>
-          <%= render 'shared/error_messages', object: f.object %>
-            <div class="mb-3">
-              <%= f.label :name, class: "form-label" %>
-              <%= f.text_field :name, class: "form-control", required: true %>
-            </div>
-            <div class="mb-3">
-              <%= f.label :email, class: "form-label" %>
-              <%= f.email_field :email, class: "form-control", required: true %>
-            </div>
-            <div class="mb-3">
-              <%= f.label :password, class: "form-label" %>
-              <%= f.password_field :password, class: "form-control", required: true %>
-            </div>
-            <div class="mb-5">
-              <%= f.label :password_confirmation, class: "form-label" %>
-              <%= f.password_field :password_confirmation, class: "form-control", required: true %>
-            </div>
-            <div class="d-grid gap-2 col-6 mx-auto">
-              <%= f.submit class: "btn btn-primary" %>
-            </div>
-          <% end %>
+  <%= form_with model: @user do |f| %>
+  <%= render 'shared/error_messages', object: f.object %>
+    <div class="card mt-5 custom-card-width">
+      <div class="container py-2 my-5">
+        <div class="row my-auto">
+          <div class="col-md-10 col-lg-8 mx-auto">
+              <div class="mb-3">
+                <%= f.label :name, class: "form-label" %>
+                <%= f.text_field :name, class: "form-control" %>
+              </div>
+              <div class="mb-3">
+                <%= f.label :email, class: "form-label" %>
+                <%= f.email_field :email, class: "form-control" %>
+              </div>
+              <div class="mb-3">
+                <%= f.label :password, class: "form-label" %>
+                <%= f.password_field :password, class: "form-control" %>
+              </div>
+              <div class="mb-5">
+                <%= f.label :password_confirmation, class: "form-label" %>
+                <%= f.password_field :password_confirmation, class: "form-control" %>
+              </div>
+              <div class="d-grid gap-2 col-6 mx-auto">
+                <%= f.submit class: "btn btn-primary" %>
+              </div>
+          </div>
         </div>
       </div>
     </div>
-  </div>
+  <% end %>
 </div>

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -29,4 +29,15 @@ ja:
         step_number: 手順の番号
         description: 作り方
       menu:
-        title: メニュータイトル：
+        title: メニュータイトル
+    errors:
+      models:
+        user:
+          attributes:
+            current_password:
+              blank: "現在のパスワードを入力してください"
+              invalid: "現在のパスワードは正しくありません"
+        menu:
+          attributes:
+            base:
+              must_have_at_least_one_recipe: メニューには少なくとも1つのレシピを選択する必要があります

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -158,10 +158,10 @@ ja:
       menu_title: メニュー表のタイトルを入力
       recipe_select: レシピを選択してください
       create: メニュー表を作成
-      no_recipes_saved: メニューに追加できるレシピがありません
+      no_recipes_saved: メニュー表に追加できるレシピがありません
     create:
-      success: メニューを作成しました
-      failure: メニューの作成に失敗しました
+      success: メニュー表を作成しました
+      failure: メニュー表の作成に失敗しました
     show:
       to_top_page: トップページへ
       title: メニュー表確認画面
@@ -177,6 +177,7 @@ ja:
     edit:
       to_top_page: トップページへ
       title: メニュー表編集
+      menu_title: メニュー表のタイトルを入力
       recipe_select: レシピを選択してください
       update: メニュー表を更新
       no_recipes_saved: メニュー表にレシピがありません

--- a/spec/factories/designs.rb
+++ b/spec/factories/designs.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :design do
-    name { "MyString" }
-    layout { "" }
+    name { "居酒屋風メニュー" }
+    layout { { "menu-title" => { "position" => "top", "font-size" => "24px" }, "recipe-title" => { "position" => "middle", "font-size" => "18px" } }.to_json }
   end
 end

--- a/spec/factories/menu_designs.rb
+++ b/spec/factories/menu_designs.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :menu_design do
-    menu { nil }
-    design { nil }
+    association :menu
+    association :design
   end
 end

--- a/spec/factories/menu_recipes.rb
+++ b/spec/factories/menu_recipes.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :menu_recipe do
-    menu { nil }
-    recipe { nil }
+    association :menu
+    association :recipe
   end
 end

--- a/spec/factories/menus.rb
+++ b/spec/factories/menus.rb
@@ -1,6 +1,19 @@
 FactoryBot.define do
   factory :menu do
-    user { nil }
+    association :user
     title { "MyString" }
+
+    transient do
+      recipes_count { 1 } # デフォルトで1つのレシピを関連付け
+    end
+
+    after(:create) do |menu, evaluator|
+      create_list(:recipe, evaluator.recipes_count).each do |recipe|
+        create(:menu_recipe, menu:, recipe:)
+      end
+
+      design = create(:design)
+      create(:menu_design, menu:, design:)
+    end
   end
 end

--- a/spec/models/design_spec.rb
+++ b/spec/models/design_spec.rb
@@ -1,5 +1,22 @@
 require 'rails_helper'
 
 RSpec.describe Design, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe 'バリデーションのテスト' do
+    it '名前が存在すること' do
+      design = build(:design, name: nil)
+      expect(design).not_to be_valid
+    end
+
+    it 'レイアウトが存在すること' do
+      design = build(:design, layout: nil)
+      expect(design).not_to be_valid
+    end
+  end
+
+  describe 'アソシエーションのテスト' do
+    it 'メニューとデザインの関連付けがあること' do
+      assoc = described_class.reflect_on_association(:menus)
+      expect(assoc.macro).to eq :has_many
+    end
+  end
 end

--- a/spec/models/menu_design_spec.rb
+++ b/spec/models/menu_design_spec.rb
@@ -1,5 +1,15 @@
 require 'rails_helper'
 
 RSpec.describe MenuDesign, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe 'アソシエーションのテスト' do
+    it 'メニューに属していること' do
+      assoc = described_class.reflect_on_association(:menu)
+      expect(assoc.macro).to eq :belongs_to
+    end
+
+    it 'デザインに属していること' do
+      assoc = described_class.reflect_on_association(:design)
+      expect(assoc.macro).to eq :belongs_to
+    end
+  end
 end

--- a/spec/models/menu_recipe_spec.rb
+++ b/spec/models/menu_recipe_spec.rb
@@ -1,5 +1,15 @@
 require 'rails_helper'
 
 RSpec.describe MenuRecipe, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe 'アソシエーションのテスト' do
+    it 'メニューに属していること' do
+      assoc = described_class.reflect_on_association(:menu)
+      expect(assoc.macro).to eq :belongs_to
+    end
+
+    it 'レシピに属していること' do
+      assoc = described_class.reflect_on_association(:recipe)
+      expect(assoc.macro).to eq :belongs_to
+    end
+  end
 end

--- a/spec/models/menu_spec.rb
+++ b/spec/models/menu_spec.rb
@@ -1,5 +1,46 @@
 require 'rails_helper'
 
 RSpec.describe Menu, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe 'バリデーションのテスト' do
+    let(:recipe) { create(:recipe) }
+    let(:menu) { create(:menu, user:, recipe_ids: [recipe.id]) }
+
+    it 'タイトルが存在すること' do
+      menu = build(:menu, title: nil)
+      expect(menu).not_to be_valid
+    end
+
+    it 'タイトルがユニークであること' do
+      recipe = create(:recipe) # 必要なレシピを作成
+      create(:menu, title: 'UniqueTitle', recipe_ids: [recipe.id]) # 同じタイトルでメニューを作成
+
+      # 新しいメニューを作成し、レシピを追加
+      new_menu = build(:menu, title: 'UniqueTitle', recipe_ids: [recipe.id])
+      new_menu.save
+
+      expect(new_menu).not_to be_valid
+    end
+
+    it '少なくとも1つのレシピが必要であること' do
+      menu = build(:menu, recipe_ids: [])
+      expect(menu).not_to be_valid
+    end
+  end
+
+  describe 'アソシエーションのテスト' do
+    it 'ユーザーに属していること' do
+      assoc = described_class.reflect_on_association(:user)
+      expect(assoc.macro).to eq :belongs_to
+    end
+
+    it 'メニューとレシピの関連付けがあること' do
+      assoc = described_class.reflect_on_association(:recipes)
+      expect(assoc.macro).to eq :has_many
+    end
+
+    it 'メニューとデザインの関連付けがあること' do
+      assoc = described_class.reflect_on_association(:designs)
+      expect(assoc.macro).to eq :has_many
+    end
+  end
 end

--- a/spec/support/system_helper.rb
+++ b/spec/support/system_helper.rb
@@ -23,6 +23,12 @@ module SystemHelper
     click_on 'ログアウト'
     click_link 'ログイン'
   end
+
+  def menu_update(first_recipe)
+    visit edit_menu_path(menu)
+    fill_in 'menu_title', with: 'Updated Menu'
+    find("input[type='checkbox'][value='#{first_recipe.id}']").uncheck
+  end
 end
 
 RSpec.configure do |config|

--- a/spec/system/menus_spec.rb
+++ b/spec/system/menus_spec.rb
@@ -1,0 +1,100 @@
+require 'rails_helper'
+
+RSpec.describe "Menus", type: :system do
+  let(:user) { create(:user) }
+  let(:design) { create(:design, name: '居酒屋風メニュー') }
+  let(:recipe) { create(:recipe) }
+  let(:menu) { create(:menu, user:, recipe_ids: [recipe.id]) }
+
+  before do
+    login(user)
+    design
+  end
+
+  describe 'メニュー表の作成' do
+    before do
+      click_link 'メニュー表作成'
+    end
+
+    it '新しいメニューを作成できること' do
+      first_recipe = create(:recipe, user:) # テスト内で作成
+      fill_in 'menu_title', with: 'New Menu'
+      find("input[type='checkbox'][value='#{first_recipe.id}']").check
+      click_button 'メニュー表を作成'
+      expect(page).to have_content('メニュー表を作成しました')
+    end
+
+    it '新しいメニューに選択したレシピが表示されること' do
+      first_recipe = create(:recipe, user:) # テスト内で作成
+      fill_in 'menu_title', with: 'New Menu'
+      find("input[type='checkbox'][value='#{first_recipe.id}']").check
+      click_button 'メニュー表を作成'
+      expect(page).to have_content(first_recipe.title)
+    end
+  end
+
+  describe 'メニュー表の詳細確認' do
+    before do
+      menu.recipes << create(:recipe, user:) # メニューに関連付け
+      menu.designs << design
+    end
+
+    it '作成したメニュー表が表示されること' do
+      visit menu_path(menu)
+      expect(page).to have_content(menu.title)
+    end
+
+    it 'メニュー表確認画面でレシピが表示されること' do
+      visit menu_path(menu)
+      expect(page).to have_content(menu.recipes.first.title)
+    end
+  end
+
+  describe 'メニュー表の一覧表示' do
+    it 'メニューの一覧に作成したメニューが表示されること' do
+      click_link 'メニュー表一覧'
+      expect(page).to have_content(menu.title)
+    end
+  end
+
+  describe 'メニュー表の編集' do
+    let!(:first_recipe) { create(:recipe, user:) } # 編集時に必要なレシピを作成
+
+    before do
+      menu.recipes << first_recipe # メニューに関連付け
+    end
+
+    it 'メニューを編集し、タイトルが更新されること' do
+      visit edit_menu_path(menu)
+      fill_in 'menu_title', with: 'Updated Menu'
+      click_button 'メニュー表を更新'
+      expect(page).to have_content('Updated Menu')
+    end
+
+    it 'メニュー編集後にレシピの変更が反映されること' do
+      second_recipe = create(:recipe, user:)
+      menu.recipes << second_recipe
+      menu_update(first_recipe)
+      click_button 'メニュー表を更新'
+      expect(page).to have_content(second_recipe.title)
+    end
+
+    it 'メニュー編集後に削除したレシピが表示されないこと' do
+      second_recipe = create(:recipe, user:)
+      menu.recipes << second_recipe
+      menu_update(first_recipe)
+      click_button 'メニュー表を更新'
+      expect(page).not_to have_content(first_recipe.title)
+    end
+  end
+
+  describe 'メニュー表の削除' do
+    it 'メニューを削除できること' do
+      visit menu_path(menu)
+      page.accept_alert('このメニュー表を削除しますか？') do
+        click_link '削除'
+      end
+      expect(page).to have_content 'メニュー表を削除しました'
+    end
+  end
+end


### PR DESCRIPTION
fix #66 
# 概要
メニュー表作成機能のテストコード作成
## 内容
- メニュー表に関して以下の内容のテストコードを作成しました。
  - モデルスペックテスト
    - menuモデル
    - designモデル
    - menu_designモデル
    - menu_recipeモデル
  - システムスペックテスト
    - メニュー表の作成
    - メニュー表の詳細確認
    - メニュー表の一覧表示
    - メニュー表の編集
    - メニュー表の削除
- バリデーションエラー時にレイアウトが崩れる問題を修正しました。
- 各種バリデーションの設定を正しく機能するよう修正しました。
- レシピ作成時、編集時に追加フォームに削除ボタンが表示されなくなる問題を修正しました。