### PR TITLE
お問い合わせ機能のテストコード作成

### DIFF
--- a/spec/factories/inquiries.rb
+++ b/spec/factories/inquiries.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :inquiry do
-    name { "MyString" }
-    email { "MyString" }
-    message { "MyText" }
+    name { Faker::Name.name }
+    email { Faker::Internet.email }
+    message { Faker::Lorem.paragraph }
   end
 end

--- a/spec/mailers/inquiry_mailer_spec.rb
+++ b/spec/mailers/inquiry_mailer_spec.rb
@@ -1,5 +1,67 @@
-require "rails_helper"
+require 'rails_helper'
 
 RSpec.describe InquiryMailer, type: :mailer do
-  pending "add some examples to (or delete) #{__FILE__}"
+  let(:inquiry) { create(:inquiry) }
+
+  describe '問い合わせメール' do
+    let(:mail) { described_class.with(inquiry:).contact_email }
+
+    it '件名が正しいこと' do
+      expect(mail.subject).to eq('新しい問い合わせ（Menu Maker）')
+    end
+
+    it '宛先が正しいこと' do
+      expect(mail.to).to eq(['your-email@example.com'])
+    end
+
+    it '送信元が正しいこと' do
+      expect(mail.from).to eq(['no-reply@example.com'])
+    end
+
+    it '本文に名前が含まれること' do
+      decoded_body = Base64.decode64(mail.body.encoded.split("\r\n\r\n")[1]).force_encoding('UTF-8')
+      expect(decoded_body).to match(inquiry.name.force_encoding('UTF-8'))
+    end
+
+    it '本文にメールアドレスが含まれること' do
+      decoded_body = Base64.decode64(mail.body.encoded.split("\r\n\r\n")[1]).force_encoding('UTF-8')
+      expect(decoded_body).to match(inquiry.email.force_encoding('UTF-8'))
+    end
+
+    it '本文にメッセージが含まれること' do
+      decoded_body = Base64.decode64(mail.body.encoded.split("\r\n\r\n")[1]).force_encoding('UTF-8')
+      expect(decoded_body).to match(inquiry.message.force_encoding('UTF-8'))
+    end
+  end
+
+  describe 'お問い合わせ内容確認メール' do
+    let(:mail) { described_class.with(inquiry:).confirmation_email }
+
+    it '件名が正しいこと' do
+      expect(mail.subject).to eq('お問い合わせ受付完了（Menu Maker）')
+    end
+
+    it '宛先が正しいこと' do
+      expect(mail.to).to eq([inquiry.email])
+    end
+
+    it '送信元が正しいこと' do
+      expect(mail.from).to eq(['no-reply@example.com'])
+    end
+
+    it '本文に名前が含まれること' do
+      decoded_body = Base64.decode64(mail.body.encoded.split("\r\n\r\n")[1]).force_encoding('UTF-8')
+      expect(decoded_body).to match(inquiry.name.force_encoding('UTF-8'))
+    end
+
+    it '本文にメールアドレスが含まれること' do
+      decoded_body = Base64.decode64(mail.body.encoded.split("\r\n\r\n")[1]).force_encoding('UTF-8')
+      expect(decoded_body).to match(inquiry.email.force_encoding('UTF-8'))
+    end
+
+    it '本文にメッセージが含まれること' do
+      decoded_body = Base64.decode64(mail.body.encoded.split("\r\n\r\n")[1]).force_encoding('UTF-8')
+      expect(decoded_body).to match(inquiry.message.force_encoding('UTF-8'))
+    end
+  end
 end

--- a/spec/mailers/previews/inquiry_mailer_preview.rb
+++ b/spec/mailers/previews/inquiry_mailer_preview.rb
@@ -1,4 +1,0 @@
-# Preview all emails at http://localhost:3000/rails/mailers/inquiry_mailer_mailer
-class InquiryMailerPreview < ActionMailer::Preview
-
-end

--- a/spec/models/inquiry_spec.rb
+++ b/spec/models/inquiry_spec.rb
@@ -1,5 +1,35 @@
 require 'rails_helper'
 
 RSpec.describe Inquiry, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe "バリデーションのテスト" do
+    it '有効な属性の場合は有効であること' do
+      inquiry = build(:inquiry)
+      expect(inquiry).to be_valid
+    end
+
+    it '名前がない場合は無効であること' do
+      inquiry = build(:inquiry, name: nil)
+      expect(inquiry).not_to be_valid
+    end
+
+    it 'メールアドレスがない場合は無効であること' do
+      inquiry = build(:inquiry, email: nil)
+      expect(inquiry).not_to be_valid
+    end
+
+    it '不正な形式のメールアドレスの場合は無効であること' do
+      inquiry = build(:inquiry, email: 'invalid_email')
+      expect(inquiry).not_to be_valid
+    end
+
+    it 'メッセージがない場合は無効であること' do
+      inquiry = build(:inquiry, message: nil)
+      expect(inquiry).not_to be_valid
+    end
+
+    it 'メッセージが500文字を超える場合は無効であること' do
+      inquiry = build(:inquiry, message: 'a' * 501)
+      expect(inquiry).not_to be_valid
+    end
+  end
 end

--- a/spec/support/system_helper.rb
+++ b/spec/support/system_helper.rb
@@ -29,6 +29,15 @@ module SystemHelper
     fill_in 'menu_title', with: 'Updated Menu'
     find("input[type='checkbox'][value='#{first_recipe.id}']").uncheck
   end
+
+  def send_inquiry(name, email, message)
+    fill_in 'inquiry_name', with: name
+    fill_in 'inquiry_email', with: email
+    fill_in 'inquiry_message', with: message
+    page.accept_alert('この内容でメールを送信しますか？') do
+      click_button '送信する'
+    end
+  end
 end
 
 RSpec.configure do |config|

--- a/spec/system/inquiries_spec.rb
+++ b/spec/system/inquiries_spec.rb
@@ -1,0 +1,39 @@
+require 'rails_helper'
+
+RSpec.describe 'お問い合わせ', type: :system do
+  it 'ユーザーが問い合わせを送信できること' do
+    visit new_inquiry_path
+    send_inquiry("Test User", "test@example.com", "This is a test inquiry.")
+    expect(page).to have_content('お問い合わせメールを送信しました')
+  end
+
+  it '問い合わせ完了画面が表示されること' do
+    visit new_inquiry_path
+    send_inquiry("Test User", "test@example.com", "This is a test inquiry.")
+    expect(page).to have_content('お問い合わせ完了')
+  end
+
+  it '名前の入力がない場合にエラーが表示されること' do
+    visit new_inquiry_path
+    page.accept_alert('この内容でメールを送信しますか？') do
+      click_button '送信する'
+    end
+    expect(page).to have_content("お名前を入力してください")
+  end
+
+  it 'メールアドレスの入力がない場合にエラーが表示されること' do
+    visit new_inquiry_path
+    page.accept_alert('この内容でメールを送信しますか？') do
+      click_button '送信する'
+    end
+    expect(page).to have_content("メールアドレスを入力してください")
+  end
+
+  it '問い合わせ内容の入力がない場合にエラーが表示されること' do
+    visit new_inquiry_path
+    page.accept_alert('この内容でメールを送信しますか？') do
+      click_button '送信する'
+    end
+    expect(page).to have_content("お問い合わせ内容を入力してください")
+  end
+end

--- a/spec/system/menus_spec.rb
+++ b/spec/system/menus_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe "Menus", type: :system do
+RSpec.describe "メニュー", type: :system do
   let(:user) { create(:user) }
   let(:design) { create(:design, name: '居酒屋風メニュー') }
   let(:recipe) { create(:recipe) }

--- a/spec/system/recipes_spec.rb
+++ b/spec/system/recipes_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe 'Recipes', type: :system do
+RSpec.describe 'レシピ', type: :system do
   let(:user) { create(:user) }
 
   before do


### PR DESCRIPTION
fix #68 
# 概要
問い合わせ機能のテストコード作成
## 内容
- 以下のファイルに問い合わせ機能に関するrspecテストのコードを作成しました。
  - spec/factories/inquiries.rb
  - spec/mailers/inquiry_mailer_spec.rb
  - spec/models/inquiry_spec.rb
  - spec/system/inquiries_spec.rb
  - spec/support/system_helper.rb
- menus_spec.rbとrecipes_spec.rbの記述を他のテストコードと合わせるように修正しました。