### PR TITLE
独自ドメインを取得

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -64,7 +64,7 @@ COPY --from=build /rails /rails
 
 # Run and own only the runtime files as a non-root user for security
 RUN useradd rails --create-home --shell /bin/bash && \
-    chown -R rails:rails db log storage tmp
+    chown -R rails:rails db log storage tmp public/assets
 USER rails:rails
 
 # Entrypoint prepares the database.

--- a/README.md
+++ b/README.md
@@ -47,9 +47,33 @@
 - アプリのSNSシェア機能
 
 ### 機能の実装方針予定
-- レシピの自動保存：gem 'mechanize'を使用
 - 保存したレシピの検索：rails-autocomplete(JQuery)を使用
 - メニュー表の画像化：html2canvas.js等を使用
+
+### 使用技術
+- フロントエンド
+  - JavaScript：@hotwired/stimulus, @hotwired/turbo-rails
+  - CSSフレームワーク：Bootstrap 5
+  - ビルドツール：esbuild
+- バックエンド
+  - Ruby: 3.3.2
+  - Ruby on Rails: 7.1.3
+- データベース
+  - PostgreSQL
+- CI/CL
+  - GitHubActions
+- インフラ
+  - Fly.io
+- ストレージ
+  - AWS S3
+- 認証
+  - Sorcery
+- その他
+  - Mechanize
+  - Rack-Attack
+  - High Voltage
+  - Gretel
+
 
 ### 画面遷移図
 Figma：https://www.figma.com/design/XGrjkiWR0n4Dlsu304WmFb/Menu-Maker?node-id=0-1&t=qKKVIaxosiTwWNMq-1

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -262,8 +262,8 @@ footer {
 }
 
 .show-recipe-photo {
-  width: 300px;
-  height: 200px;
+  width: 25rem;
+  height: 15rem;
 }
 
 .show-ingredient-row {

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,4 +1,4 @@
 class ApplicationMailer < ActionMailer::Base
-  default from: "from@example.com"
+  default from: ENV.fetch('DEFAULT_FROM_EMAIL', nil)
   layout "mailer"
 end

--- a/app/mailers/inquiry_mailer.rb
+++ b/app/mailers/inquiry_mailer.rb
@@ -1,10 +1,9 @@
 class InquiryMailer < ApplicationMailer
-  default from: 'no-reply@example.com'
-
   def contact_email
     @inquiry = params[:inquiry]
     mail(
-      to: 'your-email@example.com',
+      to: ENV.fetch('MAIL_ADDRESS', nil),
+      from: ENV.fetch('DEFAULT_FROM_EMAIL', nil),
       subject: t('.inquiry')
     )
   end
@@ -13,6 +12,7 @@ class InquiryMailer < ApplicationMailer
     @inquiry = params[:inquiry]
     mail(
       to: @inquiry.email,
+      from: ENV.fetch('DEFAULT_FROM_EMAIL', nil),
       subject: t('.confirmation_email')
     )
   end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -9,6 +9,7 @@ class UserMailer < ApplicationMailer
     @url  = edit_password_reset_url(@user.reset_password_token)
     mail(
       to: user.email,
+      from: ENV.fetch('DEFAULT_FROM_EMAIL', nil),
       subject: t('.password_reset')
     )
   end

--- a/app/models/menu.rb
+++ b/app/models/menu.rb
@@ -5,7 +5,8 @@ class Menu < ApplicationRecord
   has_many :menu_designs, dependent: :destroy
   has_many :designs, through: :menu_designs
 
-  validates :title, presence: true, uniqueness: true
+  validates :title, presence: true
+  validates :title, uniqueness: { scope: :user_id }
   validate :must_have_at_least_one_recipe
 
   private

--- a/app/models/recipe.rb
+++ b/app/models/recipe.rb
@@ -10,7 +10,8 @@ class Recipe < ApplicationRecord
   accepts_nested_attributes_for :ingredients, allow_destroy: true
   accepts_nested_attributes_for :instructions, allow_destroy: true
 
-  validates :title, presence: true, uniqueness: true
+  validates :title, presence: true
+  validates :title, uniqueness: { scope: :user_id }
   validates :source_url, format: { with: URI::DEFAULT_PARSER.make_regexp }, allow_nil: true
 
   def self.determine_source_site_name(url)

--- a/app/views/inquiry_mailer/confirmation_email.html.erb
+++ b/app/views/inquiry_mailer/confirmation_email.html.erb
@@ -10,7 +10,7 @@
     <ul>
       <li><strong>お名前:</strong> <%= @inquiry.name %></li>
       <li><strong>メールアドレス:</strong> <%= @inquiry.email %></li>
-      <li><strong>お問い合わせ内容:</strong> <%= @inquiry.message %></li>
+      <li><strong>お問い合わせ内容:</strong><br><%= @inquiry.message %></li>
     </ul>
     <p>確認の上、折り返しご連絡いたしますので、今しばらくお待ちください。</p>
   </body>

--- a/app/views/inquiry_mailer/contact_email.html.erb
+++ b/app/views/inquiry_mailer/contact_email.html.erb
@@ -7,6 +7,6 @@
     <h3>新しい問い合わせ</h3>
     <p><strong>名前:</strong> <%= @inquiry.name %></p>
     <p><strong>メールアドレス:</strong> <%= @inquiry.email %></p>
-    <p><strong>問い合わせ内容:</strong> <%= @inquiry.message %></p>
+    <p><strong>問い合わせ内容:</strong><br><%= @inquiry.message %></p>
   </body>
 </html>

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -21,13 +21,15 @@ Rails.application.configure do
   # config.require_master_key = true
 
   # Disable serving static files from `public/`, relying on NGINX/Apache to do so instead.
-  # config.public_file_server.enabled = false
+  config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
 
   # Compress CSS using a preprocessor.
   # config.assets.css_compressor = :sass
 
   # Do not fall back to assets pipeline if a precompiled asset is missed.
-  config.assets.compile = false
+  config.assets.compile = true
+
+  config.assets.paths << Rails.root.join("app", "assets", "fonts")
 
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
   # config.asset_host = "http://assets.example.com"
@@ -43,7 +45,20 @@ Rails.application.configure do
   # config.action_cable.mount_path = nil
   # config.action_cable.url = "wss://example.com/cable"
   # config.action_cable.allowed_request_origins = [ "http://example.com", /http:\/\/example.*/ ]
-  config.action_mailer.default_url_options = Settings.default_url_options.to_h
+  config.action_mailer.default_url_options = { protocol: 'https', host: 'menu-maker-app.com' }
+
+  config.action_mailer.delivery_method = :smtp
+
+  config.action_mailer.smtp_settings = {
+    address:              ENV['SMTP_SERVER'],
+    port:                 465,
+    domain:               'menu-maker-app.com',
+    user_name:            ENV['SMTP_USERNAME'],
+    password:             ENV['SMTP_PASSWORD'],
+    authentication:       'plain',
+    ssl:                  true,
+    enable_starttls_auto: true
+  }
 
   # Assume all access to the app is happening through a SSL-terminating reverse proxy.
   # Can be used together with config.force_ssl for Strict-Transport-Security and secure cookies.

--- a/db/migrate/20240806021216_add_unique_index_to_menus_and_recipes.rb
+++ b/db/migrate/20240806021216_add_unique_index_to_menus_and_recipes.rb
@@ -1,0 +1,9 @@
+class AddUniqueIndexToMenusAndRecipes < ActiveRecord::Migration[7.1]
+  def change
+    remove_index :menus, :title
+    remove_index :recipes, :title
+
+    add_index :menus, [:user_id, :title], unique: true
+    add_index :recipes, [:user_id, :title], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_07_29_053257) do
+ActiveRecord::Schema[7.1].define(version: 2024_08_06_021216) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -71,7 +71,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_29_053257) do
     t.string "title"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["title"], name: "index_menus_on_title", unique: true
+    t.index ["user_id", "title"], name: "index_menus_on_user_id_and_title", unique: true
     t.index ["user_id"], name: "index_menus_on_user_id"
   end
 
@@ -84,7 +84,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_29_053257) do
     t.datetime "scraped_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["title"], name: "index_recipes_on_title", unique: true
+    t.index ["user_id", "title"], name: "index_recipes_on_user_id_and_title", unique: true
     t.index ["user_id"], name: "index_recipes_on_user_id"
   end
 

--- a/fly.toml
+++ b/fly.toml
@@ -8,6 +8,8 @@ primary_region = 'nrt'
 console_command = '/rails/bin/rails console'
 
 [build]
+  [build.args]
+    RAILS_ENV = "production"
 
 [deploy]
   release_command = './bin/rails db:prepare'

--- a/spec/mailers/inquiry_mailer_spec.rb
+++ b/spec/mailers/inquiry_mailer_spec.rb
@@ -3,6 +3,11 @@ require 'rails_helper'
 RSpec.describe InquiryMailer, type: :mailer do
   let(:inquiry) { create(:inquiry) }
 
+  before do
+    allow(ENV).to receive(:fetch).with('MAIL_ADDRESS', nil).and_return('test-email@example.com')
+    allow(ENV).to receive(:fetch).with('DEFAULT_FROM_EMAIL', nil).and_return('test-from@example.com')
+  end
+
   describe '問い合わせメール' do
     let(:mail) { described_class.with(inquiry:).contact_email }
 
@@ -11,11 +16,11 @@ RSpec.describe InquiryMailer, type: :mailer do
     end
 
     it '宛先が正しいこと' do
-      expect(mail.to).to eq(['your-email@example.com'])
+      expect(mail.to).to eq(['test-email@example.com'])
     end
 
     it '送信元が正しいこと' do
-      expect(mail.from).to eq(['no-reply@example.com'])
+      expect(mail.from).to eq(['test-from@example.com'])
     end
 
     it '本文に名前が含まれること' do
@@ -46,7 +51,7 @@ RSpec.describe InquiryMailer, type: :mailer do
     end
 
     it '送信元が正しいこと' do
-      expect(mail.from).to eq(['no-reply@example.com'])
+      expect(mail.from).to eq(['test-from@example.com'])
     end
 
     it '本文に名前が含まれること' do

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -5,7 +5,10 @@ RSpec.describe UserMailer, type: :mailer do
     let(:user) { create :user }
     let(:mail) { described_class.reset_password_email(user) }
 
-    before { user.generate_reset_password_token! }
+    before do
+      user.generate_reset_password_token!
+      allow(ENV).to receive(:fetch).with('DEFAULT_FROM_EMAIL', nil).and_return('test-from@example.com')
+    end
 
     # メールが正しく送信されるかの確認
     it 'メールが送信されること' do
@@ -22,7 +25,7 @@ RSpec.describe UserMailer, type: :mailer do
     end
 
     it '送信元が正しいこと' do
-      expect(mail.from).to eq(['from@example.com'])
+      expect(mail.from).to eq(['test-from@example.com'])
     end
 
     # 本文のチェック

--- a/spec/models/menu_spec.rb
+++ b/spec/models/menu_spec.rb
@@ -2,27 +2,17 @@ require 'rails_helper'
 
 RSpec.describe Menu, type: :model do
   describe 'バリデーションのテスト' do
+    let(:user) { create(:user) }
     let(:recipe) { create(:recipe) }
-    let(:menu) { create(:menu, user:, recipe_ids: [recipe.id]) }
-
-    it 'タイトルが存在すること' do
-      menu = build(:menu, title: nil)
-      expect(menu).not_to be_valid
-    end
+    let!(:existing_menu) { create(:menu, user:, title: 'UniqueTitle', recipe_ids: [recipe.id]) }
 
     it 'タイトルがユニークであること' do
-      recipe = create(:recipe) # 必要なレシピを作成
-      create(:menu, title: 'UniqueTitle', recipe_ids: [recipe.id]) # 同じタイトルでメニューを作成
-
-      # 新しいメニューを作成し、レシピを追加
-      new_menu = build(:menu, title: 'UniqueTitle', recipe_ids: [recipe.id])
-      new_menu.save
-
+      new_menu = build(:menu, title: existing_menu.title, user:, recipe_ids: [recipe.id])
       expect(new_menu).not_to be_valid
     end
 
     it '少なくとも1つのレシピが必要であること' do
-      menu = build(:menu, recipe_ids: [])
+      menu = build(:menu, user:, recipe_ids: [])
       expect(menu).not_to be_valid
     end
   end

--- a/spec/system/inquiries_spec.rb
+++ b/spec/system/inquiries_spec.rb
@@ -1,6 +1,12 @@
 require 'rails_helper'
 
 RSpec.describe 'お問い合わせ', type: :system do
+  before do
+    allow(ENV).to receive(:fetch).and_call_original
+    allow(ENV).to receive(:fetch).with('MAIL_ADDRESS', nil).and_return('test-email@example.com')
+    allow(ENV).to receive(:fetch).with('DEFAULT_FROM_EMAIL', nil).and_return('test-from@example.com')
+  end
+
   it 'ユーザーが問い合わせを送信できること' do
     visit new_inquiry_path
     send_inquiry("Test User", "test@example.com", "This is a test inquiry.")

--- a/spec/system/passeord_reset_spec.rb
+++ b/spec/system/passeord_reset_spec.rb
@@ -3,6 +3,12 @@ require 'rails_helper'
 RSpec.describe 'パスワードリセット', type: :system do
   let(:user) { create :user }
 
+  before do
+    allow(ENV).to receive(:fetch).and_call_original
+    allow(ENV).to receive(:fetch).with('MAIL_ADDRESS', nil).and_return('test-email@example.com')
+    allow(ENV).to receive(:fetch).with('DEFAULT_FROM_EMAIL', nil).and_return('test-from@example.com')
+  end
+
   describe 'パスワード再設定メール送信' do
     before do
       visit new_password_reset_path


### PR DESCRIPTION
fix #53 
# 概要
独自ドメイン
# 内容
- 独自ドメインを取得し、使用できるよう設定しました。
- 独自ドメインのメールアドレスを取得し、mailerで使用できるよう設定しました。
- 本番環境での以下のエラーを修正しました。
  - 問い合わせやパスワードリセットのメールが送信されないエラー
  - メニュー表の詳細が確認できないエラー
- レシピタイトルとメニュータイトルが、ユーザー毎に一意であるように、データベースとモデルファイルのバリデーションを修正しました。
- 各種変更に伴い、rspecテストのテストコードを修正しました。
- Read.meファイルに、現段階の技術スタック欄を追記しました。