### PR TITLE
レシピ検索ページにリンク追加

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -113,12 +113,41 @@ footer {
   border: none; /* ボーダーを消す　*/
   letter-spacing: 10px; /* 文字の間隔　*/
   font-size: 30px; /* 文字サイズ　*/
-  padding-left: 10rem;
-  padding-right: 10rem;
+  width: 45rem;
+  padding-left: 5rem;
+  padding-right: 5rem;
   margin-bottom: 5rem;
 }
 .btn-cookpad:hover {
   background-color: #d07301 ; /* ホバー時の色 */
+}
+
+.btn-delish-kitchen {
+  background-color: #FFD200; /* ボタンの色　*/
+  border: none; /* ボーダーを消す　*/
+  letter-spacing: 10px; /* 文字の間隔　*/
+  font-size: 30px; /* 文字サイズ　*/
+  width: 45rem;
+  padding-left: 5rem;
+  padding-right: 5rem;
+  margin-bottom: 5rem;
+}
+.btn-delish-kitchen:hover {
+  background-color: #d6af02 ; /* ホバー時の色 */
+}
+
+.btn-kurashiru {
+  background-color: #E55329; /* ボタンの色　*/
+  border: none; /* ボーダーを消す　*/
+  letter-spacing: 10px; /* 文字の間隔　*/
+  font-size: 30px; /* 文字サイズ　*/
+  width: 45rem;
+  padding-left: 5rem;
+  padding-right: 5rem;
+  margin-bottom: 5rem;
+}
+.btn-kurashiru:hover {
+  background-color: #c24421 ; /* ホバー時の色 */
 }
 
 .save-options-auto {
@@ -156,6 +185,7 @@ footer {
   max-width: 90%; /* 必要に応じて調整 */
   margin: auto; /* カードを中央揃えにする */
   background-color: #FFD982;
+  padding: 0 1rem;
 }
 
 .form-group {
@@ -225,8 +255,8 @@ footer {
 }
 
 .recipe-photo {
-  width: 150px;
-  height: 100px;
+  width: 100%;
+  height: 100%;
 }
 
 .btn-recipe-edit {
@@ -262,8 +292,8 @@ footer {
 }
 
 .show-recipe-photo {
-  width: 25rem;
-  height: 15rem;
+  width: 100%;
+  height: auto;
 }
 
 .show-ingredient-row {
@@ -482,6 +512,16 @@ footer {
     font-size: 1.5rem;
     margin-bottom: 3rem;
   }
+  .btn-delish-kitchen {
+    letter-spacing: 7px;
+    font-size: 1.5rem;
+    margin-bottom: 3rem;
+  }
+  .btn-kurashiru {
+    letter-spacing: 7px;
+    font-size: 1.5rem;
+    margin-bottom: 3rem;
+  }
 
   .manual-save-form-label {
     font-size: 25px;
@@ -546,8 +586,8 @@ footer {
   }
 
   .recipe-photo {
-    width: 90px;
-    height: 60px;
+    width: 100%;
+    height: auto;
   }
   .btn-recipe-edit {
     letter-spacing: 10px; /* 文字の間隔　*/
@@ -567,8 +607,8 @@ footer {
   }
 
   .show-recipe-photo {
-    width: 200px;
-    height: 150px;
+    width: 100%;
+    height: auto;
   }
   .subtitle {
     font-size: 20px;
@@ -670,6 +710,20 @@ footer {
     padding-right: 2.5rem;
     margin-bottom: 2rem;
   }
+  .btn-delish-kitchen {
+    letter-spacing: 2px;
+    font-size: 15px;
+    padding-left: 3rem;
+    padding-right: 2.5rem;
+    margin-bottom: 2rem;
+  }
+  .btn-kurashiru {
+    letter-spacing: 2px;
+    font-size: 15px;
+    padding-left: 3rem;
+    padding-right: 2.5rem;
+    margin-bottom: 2rem;
+  }
 
   .save-options-auto {
     background-color: #F78700;
@@ -761,8 +815,8 @@ footer {
   }
 
   .recipe-photo {
-    width: 70px;
-    height: 50px;
+    width: 100%;
+    height: auto;
   }
 
   .recipe-title {
@@ -788,8 +842,8 @@ footer {
   }
 
   .show-recipe-photo {
-    width: 170px;
-    height: 130px;
+    width: 100%;
+    height: auto;
   }
 
   .show-ingredient-row {

--- a/app/views/recipes/auto_save.html.erb
+++ b/app/views/recipes/auto_save.html.erb
@@ -17,6 +17,7 @@
         <%= f.label :source_url, class: "form-label mx-auto" %>
         <%= f.text_field :source_url, class: "form-control mx-auto", placeholder: t('.enter_the_url'), required: true %>
       </div>
+      <p style="color: #F68655;"><br>※ レシピの自動保存は「Cookpad」「DELISH KITCHEN」「クラシル」のみ対応しています。</p>
       <div class="row my-5">
         <div class="col d-flex justify-content-center align-items-center">
           <%= f.submit t('.fetch_recipe'), class: "btn btn-primary", data: { turbo: false } %>

--- a/app/views/recipes/search.html.erb
+++ b/app/views/recipes/search.html.erb
@@ -16,6 +16,15 @@
         <%= link_to t('.cookpad'), "https://cookpad.com/", class: 'btn btn-cookpad', target: "_blank" %>
       </div>
     </div>
-    <p class="pb-3">※ 現在、レシピの自動保存は「Cookpad」のレシピURLのみに対応しています。</p>
+    <div class="row">
+      <div class="col d-flex justify-content-center align-items-center">
+        <%= link_to t('.delish_kitchen'), "https://delishkitchen.tv/", class: 'btn btn-delish-kitchen', target: "_blank" %>
+      </div>
+    </div>
+    <div class="row">
+      <div class="col d-flex justify-content-center align-items-center">
+        <%= link_to t('.kurashiru'), "https://www.kurashiru.com/", class: 'btn btn-kurashiru', target: "_blank" %>
+      </div>
+    </div>
   </div>
 </div>

--- a/app/views/recipes/show.html.erb
+++ b/app/views/recipes/show.html.erb
@@ -15,8 +15,15 @@
       <div class="col-12 d-flex justify-content-center">
         <h2><%= @recipe.title %></h2>
       </div>
+      <div class="col-11 d-flex justify-content-end">
+        <% if @recipe.source_site_name.present? %>
+          <p>出典: <%= link_to @recipe.source_site_name, @recipe.source_url, class: "no-underline", target: "_blank" %></p>
+        <% else %>
+          <p>出典: 自作レシピ</p>
+        <% end %>
+      </div>
     </div>
-    <div class="container px-5">
+    <div class="container px-3">
       <div class="row">
         <div class="col-md-6 col-12">
           <div class="container px-3">

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -89,6 +89,8 @@ ja:
       to_top_page: トップページへ
       title: レシピ検索
       cookpad: Cookpadから探す
+      delish_kitchen: DELISH KITCHENから探す
+      kurashiru: クラシルから探す
     save_options:
       to_top_page: トップページへ
       title: レシピの保存方法


### PR DESCRIPTION
fix #139 
# 概要
レシピ検索ページへリンク追加
## 内容
- レシピ検索ページに「DELISH KITCHEN」と「クラシル」のサイトへのリンクを追加で設置しました。
- レシピ詳細ページに、レシピのソースサイト名の表示を追加し、サイト名をソースURLへのリンクにしました。
- 自動保存ページに、対応しているサイトに関する注意書きを追加しました。
- 編集した各ページのレイアアウトを調整しました。