### PR TITLE
メニュー表の検索機能を実装

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -493,6 +493,7 @@ footer {
 }
 
 .search-form {
+  position: relative;
   margin-top: 3rem;
   padding-right: 1rem;
   margin-right: 3rem;
@@ -504,6 +505,22 @@ footer {
 .search-field {
   height: 2rem;
   width: 13rem;
+}
+.list-group {
+  position: absolute; /* 絶対位置を設定 */
+  top: 2rem; /* フォームの下に配置 */
+  min-width: 13rem; /* フォームの幅に合わせる */
+  max-width: 100%; /* 最大幅を設定、必要に応じて調整 */
+  z-index: 1000; /* 他の要素の上に表示 */
+  max-height: 8rem;
+  overflow-x: auto; /* 横スクロールを有効にする */
+  white-space: nowrap; /* テキストを折り返さない */
+}
+.list-group-item {
+  height: 2rem;
+  display: flex;
+  align-items: center;
+  padding-left: 0.2rem;
 }
 .btn-search {
   background-color: #c4c4c4; /* ボタンの色　*/
@@ -667,6 +684,11 @@ footer {
 
   .search-field {
     width: 12rem;
+    font-size: 15px;
+  }
+  .list-group {
+    min-width: 12rem; /* フォームの幅に合わせる */
+    font-size: 15px;
   }
 }
 
@@ -1030,6 +1052,16 @@ footer {
   .search-field {
     height: 1.5rem;
     width: 6rem;
+  }
+  .list-group {
+    top: 1.5rem; /* フォームの下に配置 */
+    min-width: 6rem; /* フォームの幅に合わせる */
+    max-width: 11rem; /* 最大幅を設定、必要に応じて調整 */
+    max-height: 6rem;
+  }
+  .list-group-item {
+    height: 1.5rem;
+    font-size: 8px;
   }
   .btn-search {
     background-color: #c4c4c4; /* ボタンの色　*/

--- a/app/controllers/recipes_controller.rb
+++ b/app/controllers/recipes_controller.rb
@@ -58,12 +58,14 @@ class RecipesController < ApplicationController
   end
 
   def autocomplete_title
-    @search_results = Recipe.where("title like ?", "%#{params[:q]}%").pluck(:title)
+    @search_results = current_user.recipes.where("title like ?", "%#{params[:q]}%").pluck(:title)
     render layout: false
   end
 
   def autocomplete_ingredients
-    @search_results = Ingredient.where("name like ?", "%#{params[:q]}%").distinct.pluck(:name)
+    user_recipe_ids = Recipe.where(user_id: current_user.id).pluck(:id)
+    user_ingredients = Ingredient.where(recipe_id: user_recipe_ids)
+    @search_results = user_ingredients.where("name LIKE ?", "%#{params[:q]}%").distinct(true).pluck(:name)
     render layout: false
   end
 

--- a/app/models/menu.rb
+++ b/app/models/menu.rb
@@ -9,6 +9,16 @@ class Menu < ApplicationRecord
   validates :title, uniqueness: { scope: :user_id }
   validate :must_have_at_least_one_recipe
 
+  # racsackで検索可能な属性を指定
+  def self.ransackable_attributes(_auth_object = nil)
+    ["title"]
+  end
+
+  # 関連モデルも検索対象に指定
+  def self.ransackable_associations(_auth_object = nil)
+    ["recipes"]
+  end
+
   private
 
   def must_have_at_least_one_recipe

--- a/app/models/recipe.rb
+++ b/app/models/recipe.rb
@@ -28,7 +28,7 @@ class Recipe < ApplicationRecord
 
   # racsackで検索可能な属性を指定
   def self.ransackable_attributes(_auth_object = nil)
-    ["title", "source_site_name"]
+    ["title"]
   end
 
   # 関連モデルも検索対象に指定

--- a/app/views/menus/_recipes_search_form.html.erb
+++ b/app/views/menus/_recipes_search_form.html.erb
@@ -1,17 +1,17 @@
-<%= search_form_for @q, html: { class: 'd-flex' } do |f| %>
+<%= search_form_for @q, url: new_menu_path, method: :get, html: { class: 'd-flex' } do |f| %>
   <div class="form-group">
     <div data-controller="autocomplete" data-autocomplete-url-value="/recipes/autocomplete_title" role="combobox">
-      <%= f.search_field :title_cont, data: { autocomplete_target: 'input' }, placeholder: t('search_form.title_search'), class: "search-field" %>
+      <%= f.search_field :title_cont, data: { autocomplete_target: 'input' }, placeholder: t('recipes_search_form.title_search'), class: "search-field" %>
       <%= f.hidden_field :title, data: { autocomplete_target: 'hidden' } %>
       <ul data-autocomplete-target="results" class="list-group"></ul>
     </div>
   </div>
   <div class="form-group">
     <div data-controller="autocomplete" data-autocomplete-url-value="/recipes/autocomplete_ingredients" role="combobox">
-      <%= f.search_field :ingredients_name_cont, data: { autocomplete_target: 'input' }, placeholder: t('search_form.ingredients_search'), class: "search-field" %>
+      <%= f.search_field :ingredients_name_cont, data: { autocomplete_target: 'input' }, placeholder: t('recipes_search_form.ingredients_search'), class: "search-field" %>
       <%= f.hidden_field :ingredients_name, data: { autocomplete_target: 'hidden' } %>
       <ul data-autocomplete-target="results" class="list-group"></ul>
     </div>
   </div>
-  <%= f.submit t('search_form.submit'), class: "btn btn-search", data: { turbo: false } %>
+  <%= f.submit t('recipes_search_form.submit'), class: "btn btn-search", data: { turbo: false } %>
 <% end %>

--- a/app/views/menus/_search_form.html.erb
+++ b/app/views/menus/_search_form.html.erb
@@ -1,0 +1,17 @@
+<%= search_form_for @q, html: { class: 'd-flex' } do |f| %>
+  <div class="form-group">
+    <div data-controller="autocomplete" data-autocomplete-url-value="/menus/autocomplete_title" role="combobox">
+      <%= f.search_field :title_cont, data: { autocomplete_target: 'input' }, placeholder: t('menus_search_form.title_search'), class: "search-field" %>
+      <%= f.hidden_field :title, data: { autocomplete_target: 'hidden' } %>
+      <ul data-autocomplete-target="results" class="list-group"></ul>
+    </div>
+  </div>
+  <div class="form-group">
+    <div data-controller="autocomplete" data-autocomplete-url-value="/menus/autocomplete_recipes" role="combobox">
+      <%= f.search_field :recipes_title_cont, data: { autocomplete_target: 'input' }, placeholder: t('menus_search_form.recipes_search'), class: "search-field" %>
+      <%= f.hidden_field :recipes_title, data: { autocomplete_target: 'hidden' } %>
+      <ul data-autocomplete-target="results" class="list-group"></ul>
+    </div>
+  </div>
+  <%= f.submit t('menus_search_form.submit'), class: "btn btn-search", data: { turbo: false } %>
+<% end %>

--- a/app/views/menus/autocomplete_recipes.html.erb
+++ b/app/views/menus/autocomplete_recipes.html.erb
@@ -1,0 +1,3 @@
+<% @search_results.each do |result| %>
+  <li class="list-group-item" role="option"><%= result %></li>
+<% end %>

--- a/app/views/menus/autocomplete_title.html.erb
+++ b/app/views/menus/autocomplete_title.html.erb
@@ -1,0 +1,3 @@
+<% @search_results.each do |result| %>
+  <li class="list-group-item" role="option"><%= result %></li>
+<% end %>

--- a/app/views/menus/index.html.erb
+++ b/app/views/menus/index.html.erb
@@ -9,6 +9,11 @@
       <%= link_to t('.to_top_page'), root_path, class: "custom-link", data: { turbo: false } %>
     </div>
   </div>
+
+  <div class="search-form d-flex justify-content-end">
+    <%= render 'search_form' %>
+  </div>
+
   <h1 class="page-title text-center"><%= t('.title') %></h1>
   <% if @menus.any? %>
     <div class="container mb-5">

--- a/app/views/menus/new.html.erb
+++ b/app/views/menus/new.html.erb
@@ -9,6 +9,11 @@
       <%= link_to t('.to_top_page'), root_path, class: "custom-link", data: { turbo: false } %>
     </div>
   </div>
+
+  <div class="search-form d-flex justify-content-end">
+    <%= render 'recipes_search_form' %>
+  </div>
+
   <h1 class="page-title text-center"><%= t('.title') %></h1>
   <% if @recipes.present? %>
     <%= form_with model: @menu do |f| %>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -153,8 +153,9 @@ ja:
     instruction_description: 作り方を入力
     remove: x
   search_form:
-    title_search: タイトル
+    title_search: レシピタイトル
     ingredients_search: 材料名
+    submit: 検索
   menus:
     new:
       to_top_page: トップページへ
@@ -188,6 +189,14 @@ ja:
       failure: メニュー表の更新に失敗しました
     destroy:
       success: メニュー表を削除しました
+  menus_search_form:
+    title_search: メニュータイトル
+    recipes_search: レシピタイトル
+    submit: 検索
+  recipes_search_form:
+    title_search: レシピタイトル
+    ingredients_search: 材料名
+    submit: 絞り込み
   pages:
     privacy:
       to_top_page: トップページへ

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,7 +24,12 @@ Rails.application.routes.draw do
       get 'autocomplete_ingredients' # 材料名検索のautocomplete
     end
   end
-  resources :menus
+  resources :menus do
+    collection do
+      get 'autocomplete_title' # メニュータイトル検索のautocomplete
+      get 'autocomplete_recipes' # レシピ名でのメニュー検索のautocomplete
+    end
+  end
   get 'login', to: 'user_sessions#new'  # ログインページに対応するルート
   post 'login', to: 'user_sessions#create'
   delete 'logout', to: 'user_sessions#destroy'


### PR DESCRIPTION
fix #143 
# 概要
メニュー表の検索機能
## 内容
- メニュー表一覧に検索フォームを設置し、メニュータイトルとメニューに含まれているレシピのタイトルからメニュー表を検索できるように、検索機能を実装しました。
- メニュー表作成画面で、表示されるレシピに関しても、レシピ一覧と同様に検索（絞り込み）フォームを設置し、レシピの絞り込みができるように設定しました。
- それぞれの検索フォームでオートコンプリート機能を実装しました。