### PR TITLE
メニュー表の画像化機能のテストコード作成

### DIFF
--- a/spec/system/menus_spec.rb
+++ b/spec/system/menus_spec.rb
@@ -48,6 +48,11 @@ RSpec.describe "メニュー", type: :system do
       visit menu_path(menu)
       expect(page).to have_content(menu.recipes.first.title)
     end
+
+    it 'メニュー表が画像として表示されること' do
+      visit menu_path(menu)
+      expect(page).to have_selector('#menu-image')
+    end
   end
 
   describe 'メニュー表の一覧表示' do


### PR DESCRIPTION
fix #155 
# 概要
メニュー表の画像化機能のテストコード作成
## 内容
- メニュー表詳細画面で表示されるメニュー表が、画像で表示されていることをテストするコードを追加しました。