### PR TITLE
Recipe search update

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -694,6 +694,24 @@ footer {
   color: #499342;
 }
 
+.recipe-item {
+  display: flex;
+  align-items: center;
+  margin-bottom: 10px;
+}
+
+.recipe-item h3 {
+  margin: 0;
+  display: inline;
+}
+
+.recipe-item p {
+  margin-left: 10px;
+  padding-top: 1rem;
+  font-size: 0.9em;
+  color: #666;
+}
+
 /* タブレット向けのスタイル */
 @media (min-width: 768px) and (max-width: 1024px) {
   body {

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -712,6 +712,22 @@ footer {
   color: #666;
 }
 
+.nav-item .nav-link {
+  color: #4C4C4C;
+}
+.nav-item .nav-link.active {
+  background-color: #fbd063;
+  border-color: #F78700;
+  border-width: 2px;
+}
+.nav-tabs {
+  border-bottom-width: 3px;
+  border-color: #F78700;
+}
+.nav-tabs .nav-link:hover {
+  border-width: 2px;
+  border-color: #F78700;
+}
 /* タブレット向けのスタイル */
 @media (min-width: 768px) and (max-width: 1024px) {
   body {

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -987,6 +987,10 @@ footer {
   .source-site {
     font-size: 16px;
   }
+
+  .nav {
+    --bs-nav-link-padding-x: 1.5rem;
+  }
 }
 
 /* スマートフォンサイズ用のスタイル */
@@ -1510,5 +1514,21 @@ footer {
     margin-left: 0.5rem;
     letter-spacing: 0.05rem;
     margin-bottom: 2rem;
+  }
+
+  .nav {
+    --bs-nav-link-padding-x: 0.6rem;
+  }
+  .nav-item .nav-link {
+    font-size: 10px;
+  }
+
+  .recipe-item h3 {
+    font-size: 1.1rem;
+  }
+  .recipe-item p {
+    margin-left: 0.2rem;
+    font-size: 0.5rem;
+    width: 4rem;
   }
 }

--- a/app/controllers/recipes_controller.rb
+++ b/app/controllers/recipes_controller.rb
@@ -88,6 +88,17 @@ class RecipesController < ApplicationController
     @recipe = Recipe.new
   end
 
+  def save_recipe
+    url = params[:recipe][:source_url]
+    if url.present?
+      fetch_recipe_params = {source_url: url}
+      fetch_recipe
+    else
+      flash[:danger] = t('.missing_url')
+      redirect_to request.referer || root_path
+    end
+  end
+
   def fetch_recipe
     service = scraper_for(fetch_recipe_params[:source_url]) # 入力されたsource_urlをscraper_forメソッドに渡す
     basic_info = service.fetch_basic_info # serviceオブジェクトのfetch_basic_infoメソッドを呼び出し

--- a/app/controllers/recipes_controller.rb
+++ b/app/controllers/recipes_controller.rb
@@ -12,6 +12,8 @@ class RecipesController < ApplicationController
       @recipes += scrape_cookpad(@query)
       # DELISH KITCHENからレシピを取得
       @recipes += scrape_delish_kitchen(@query)
+      # クラシルからレシピを取得
+      @recipes += scrape_kurashiru(@query)
     end
     
     render :search
@@ -195,6 +197,24 @@ class RecipesController < ApplicationController
       title = title_element.text.strip
       source_url = "https://delishkitchen.tv" + recipe_element.at('a')['href']
       recipes << { title: title, source_url: source_url, site_name: 'DELISH KITCHEN' }
+    end
+    recipes
+  end
+
+  # クラシルのスクレイピング処理
+  def scrape_kurashiru(query)
+    agent = Mechanize.new
+    recipes = []
+    search_url = "https://kurashiru.com/search?query=#{CGI.escape(query)}"
+    page = agent.get(search_url)
+
+    page.search('.DlyMasonry-container .DlyMasonry-content').each do |recipe_element|
+      title_element = recipe_element.at('.video-list-title a.title')
+      next unless title_element
+
+      title = title_element.text.strip
+      source_url = "https://kurashiru.com" + recipe_element.at('a.thumbnail-wrapper')['href']
+      recipes << { title: title, source_url: source_url, site_name: 'クラシル' }
     end
     recipes
   end

--- a/app/controllers/recipes_controller.rb
+++ b/app/controllers/recipes_controller.rb
@@ -17,7 +17,7 @@ class RecipesController < ApplicationController
     end
 
     @recipes.sort_by! { |recipe| recipe[:title].to_s }
-    
+
     render :search
   end
 
@@ -30,53 +30,53 @@ class RecipesController < ApplicationController
 
     case URI.parse(@source_site_url).host
     when /cookpad/
-      @title = page.at('h1.break-words').text.strip  # レシピタイトル
-      @image_url = page.at('picture img')['src']  # レシピ画像URL
+      @title = page.at('h1.break-words').text.strip # レシピタイトル
+      @image_url = page.at('picture img')['src'] # レシピ画像URL
       @ingredients = page.search('#ingredients .ingredient-list ol li').map do |ingredient|
         {
-          name: ingredient.at('span')&.text.strip,
-          quantity: ingredient.at('bdi')&.text.strip
+          name: ingredient.at('span')&.text&.strip,
+          quantity: ingredient.at('bdi')&.text&.strip
         }
       end
       @steps = page.search('#steps ol li.step').map do |step|
         {
-          number: step.at('.flex-shrink-0')&.text.strip,
-          instruction: step.at('p')&.text.strip
+          number: step.at('.flex-shrink-0')&.text&.strip,
+          instruction: step.at('p')&.text&.strip
         }
       end
     when /delishkitchen/
       lead_text = page.at('.title-box .lead').text.strip
       title_text = page.at('.title-box .title').text.strip
-      @title = "#{lead_text} #{title_text}"  # レシピタイトル
-      @image_url = page.at('.video-player video')['poster']  # レシピ画像URL
+      @title = "#{lead_text} #{title_text}" # レシピタイトル
+      @image_url = page.at('.video-player video')['poster'] # レシピ画像URL
       @ingredients = page.search('.ingredient-list li.ingredient').map do |ingredient|
         {
-          name: ingredient.at('.ingredient-name')&.text.strip,
-          quantity: ingredient.at('.ingredient-serving')&.text.strip
+          name: ingredient.at('.ingredient-name')&.text&.strip,
+          quantity: ingredient.at('.ingredient-serving')&.text&.strip
         }
       end
       @steps = page.search('ol.steps li.step').map do |step|
         {
-          number: step.at('.step-num')&.text.strip,
-          instruction: step.at('.step-desc')&.text.strip
+          number: step.at('.step-num')&.text&.strip,
+          instruction: step.at('.step-desc')&.text&.strip
         }
       end
     when /kurashiru/
       title_text = page.at('.title-wrapper .title').text.strip
-      @title = title_text.gsub(/　レシピ・作り方$/, '')  # レシピタイトル
-      @image_url = page.at('.video-wrapper .video video')['poster']  # レシピ画像URL
+      @title = title_text.gsub(/　レシピ・作り方$/, '') # レシピタイトル
+      @image_url = page.at('.video-wrapper .video video')['poster'] # レシピ画像URL
       @ingredients = page.search('.ingredient-list li.ingredient-list-item').filter_map do |ingredient|
         next if ingredient['class'].include?('group-title')
 
         {
-          name: ingredient.at('.ingredient-name')&.text.strip,
-          quantity: ingredient.at('.ingredient-quantity-amount')&.text.strip
+          name: ingredient.at('.ingredient-name')&.text&.strip,
+          quantity: ingredient.at('.ingredient-quantity-amount')&.text&.strip
         }
       end
       @steps = page.search('ol.instruction-list li.instruction-list-item').map do |step|
         {
-          number: step.at('.sort-order')&.text.strip.gsub('.', ''),
-          instruction: step.at('.content')&.text.strip
+          number: step.at('.sort-order')&.text&.strip&.delete('.'),
+          instruction: step.at('.content')&.text&.strip
         }
       end
     else
@@ -93,7 +93,6 @@ class RecipesController < ApplicationController
   def save_recipe
     url = params[:recipe][:source_url]
     if url.present?
-      fetch_recipe_params = {source_url: url}
       fetch_recipe
     else
       flash[:danger] = t('.missing_url')
@@ -253,8 +252,8 @@ class RecipesController < ApplicationController
       next unless title_element
 
       title = title_element.text.strip
-      source_url = "https://cookpad.com" + title_element['href']
-      recipes << { title: title, source_url: source_url, site_name: 'Cookpad' }
+      source_url = "https://cookpad.com#{title_element['href']}"
+      recipes << { title:, source_url:, site_name: 'Cookpad' }
     end
     recipes
   end
@@ -271,8 +270,8 @@ class RecipesController < ApplicationController
       next unless title_element
 
       title = title_element.text.strip
-      source_url = "https://delishkitchen.tv" + recipe_element.at('a')['href']
-      recipes << { title: title, source_url: source_url, site_name: 'DELISH KITCHEN' }
+      source_url = "https://delishkitchen.tv#{recipe_element.at('a')['href']}"
+      recipes << { title:, source_url:, site_name: 'DELISH KITCHEN' }
     end
     recipes
   end
@@ -289,8 +288,8 @@ class RecipesController < ApplicationController
       next unless title_element
 
       title = title_element.text.strip
-      source_url = "https://kurashiru.com" + recipe_element.at('a.thumbnail-wrapper')['href']
-      recipes << { title: title, source_url: source_url, site_name: 'クラシル' }
+      source_url = "https://kurashiru.com#{recipe_element.at('a.thumbnail-wrapper')['href']}"
+      recipes << { title:, source_url:, site_name: 'クラシル' }
     end
     recipes
   end

--- a/app/controllers/recipes_controller.rb
+++ b/app/controllers/recipes_controller.rb
@@ -15,6 +15,8 @@ class RecipesController < ApplicationController
       # クラシルからレシピを取得
       @recipes += scrape_kurashiru(@query)
     end
+
+    @recipes.sort_by! { |recipe| recipe[:title].to_s }
     
     render :search
   end

--- a/app/controllers/recipes_controller.rb
+++ b/app/controllers/recipes_controller.rb
@@ -176,10 +176,26 @@ class RecipesController < ApplicationController
 
       title = title_element.text.strip
       source_url = "https://cookpad.com" + title_element['href']
-      image_url = recipe_element.at('.flex-none picture img')['src'] if recipe_element.at('picture img')
-      recipes << { title: title, source_url: source_url, image_url: image_url, site_name: 'Cookpad' }
+      recipes << { title: title, source_url: source_url, site_name: 'Cookpad' }
     end
     recipes
   end
 
+  # DELISH KITCHENのスクレイピング処理
+  def scrape_delish_kitchen(query)
+    agent = Mechanize.new
+    recipes = []
+    search_url = "https://delishkitchen.tv/search?q=#{CGI.escape(query)}"
+    page = agent.get(search_url)
+
+    page.search('.delish-recipes .delish-recipe-item-card').each do |recipe_element|
+      title_element = recipe_element.at('.item-card__title')
+      next unless title_element
+
+      title = title_element.text.strip
+      source_url = "https://delishkitchen.tv" + recipe_element.at('a')['href']
+      recipes << { title: title, source_url: source_url, site_name: 'DELISH KITCHEN' }
+    end
+    recipes
+  end
 end

--- a/app/controllers/recipes_controller.rb
+++ b/app/controllers/recipes_controller.rb
@@ -19,6 +19,27 @@ class RecipesController < ApplicationController
     render :search
   end
 
+  def search_show
+    url = params[:url]
+    agent = Mechanize.new
+    page = agent.get(url)
+  
+    @title = page.at('h1.break-words').text.strip  # レシピタイトル
+    @image_url = page.at('picture img')['src']  # レシピ画像URL
+    @ingredients = page.search('#ingredients .ingredient-list ol li').map do |ingredient|
+      {
+        name: ingredient.at('span')&.text.strip,
+        quantity: ingredient.at('bdi')&.text.strip
+      }
+    end
+    @steps = page.search('#steps ol li.step').map do |step|
+      {
+        number: step.at('.flex-shrink-0')&.text.strip,
+        instruction: step.at('p')&.text.strip
+      }
+    end
+  end
+
   def save_options; end
 
   def auto_save

--- a/app/services/recipe_scrapers/recipe_scraper.rb
+++ b/app/services/recipe_scrapers/recipe_scraper.rb
@@ -23,15 +23,13 @@ module RecipeScrapers
       }
     end
 
-    private
-
     def determine_source_site_name(url)
       case URI.parse(url).host # URLを解析＆解析したURLのホスト名（ドメイン）を取得し、取得したホスト名についての条件分岐
       when 'cookpad.com'
         'Cookpad' # ホスト名が'cookpad.com'のときに'Cookpad'を返す
       when 'delishkitchen.tv'
         'DELISH KITCHEN'
-      when 'www.kurashiru.com'
+      when 'kurashiru.com'
         'クラシル'
       else
         URI.parse(url).host # 条件に当てはまらない場合は、ホスト名をそのまま返す

--- a/app/views/recipes/auto_save.html.erb
+++ b/app/views/recipes/auto_save.html.erb
@@ -10,6 +10,23 @@
     </div>
   </div>
   <h1 class="page-title text-center"><%= t('.title') %></h1>
+  <div class="page-container text-center px-3">
+    <div class="row">
+      <div class="col d-flex justify-content-center align-items-center">
+        <%= link_to t('.cookpad'), "https://cookpad.com/", class: 'btn btn-cookpad', target: "_blank" %>
+      </div>
+    </div>
+    <div class="row">
+      <div class="col d-flex justify-content-center align-items-center">
+        <%= link_to t('.delish_kitchen'), "https://delishkitchen.tv/", class: 'btn btn-delish-kitchen', target: "_blank" %>
+      </div>
+    </div>
+    <div class="row">
+      <div class="col d-flex justify-content-center align-items-center">
+        <%= link_to t('.kurashiru'), "https://www.kurashiru.com/", class: 'btn btn-kurashiru', target: "_blank" %>
+      </div>
+    </div>
+  </div>
   <div class="page-container px-5">
     <%= form_with model: @recipe, url: fetch_recipe_recipes_path do |f| %>
     <%= render 'shared/error_messages', object: f.object %>

--- a/app/views/recipes/search.html.erb
+++ b/app/views/recipes/search.html.erb
@@ -28,3 +28,30 @@
     </div>
   </div>
 </div>
+<h1>レシピ検索</h1>
+
+<!-- 検索フォーム -->
+<%= form_with url: search_recipes_path, method: :get, local: true do %>
+  <div>
+    <%= label_tag :query, "レシピを検索" %>
+    <%= text_field_tag :query, params[:query], placeholder: "例: カレー" %>
+    <%= submit_tag "検索" %>
+  </div>
+<% end %>
+
+<!-- 検索結果表示 -->
+<% if @recipes.present? %>
+  <h2>検索結果:</h2>
+  <ul>
+    <% @recipes.each do |recipe| %>
+      <li>
+        <h3><%= link_to recipe[:title], recipe[:source_url], target: "_blank" %></h3>
+        <p><%= recipe[:site_name] %></p>
+        <%= image_tag recipe[:image_url], alt: recipe[:title], width: 150 if recipe[:image_url].present? %>
+      </li>
+    <% end %>
+  </ul>
+<% elsif params[:query].present? %>
+  <p>該当するレシピは見つかりませんでした。</p>
+<% end %>
+

--- a/app/views/recipes/search.html.erb
+++ b/app/views/recipes/search.html.erb
@@ -26,7 +26,7 @@
       <ul>
         <% @recipes.each do |recipe| %>
           <li class="recipe-item">
-            <h3><%= link_to recipe[:title], recipe[:source_url], target: "_blank" %></h3>
+            <h3><%= link_to recipe[:title], search_show_recipes_path(url: recipe[:source_url]) %></h3>
             <p><%= "（#{recipe[:site_name]}）" %></p>
             <%= image_tag recipe[:image_url], alt: recipe[:title], width: 150 if recipe[:image_url].present? %>
           </li>

--- a/app/views/recipes/search.html.erb
+++ b/app/views/recipes/search.html.erb
@@ -10,7 +10,7 @@
     </div>
   </div>
   <h1 class="page-title text-center"><%= t('.title') %></h1>
-  <div class="page-container text-start px-3">
+  <div class="page-container text-start px-3 mb-5">
     <!-- 検索フォーム -->
     <%= form_with url: search_recipes_path, method: :get, local: true do %>
       <div class="text-center">
@@ -22,15 +22,69 @@
     
     <!-- 検索結果表示 -->
     <% if @recipes.present? %>
-      <h2 class="px-5 pt-5 pb-3">検索結果：</h2>
-      <ul>
-        <% @recipes.each do |recipe| %>
-          <li class="recipe-item">
-            <h3><%= link_to recipe[:title], search_show_recipes_path(source_url: recipe[:source_url]) %></h3>
-            <p><%= "（#{recipe[:site_name]}）" %></p>
+      <div class="tabs pb-5">
+        <ul class="nav nav-tabs my-5">
+          <li class="nav-item">
+            <button class="nav-link active" data-bs-toggle="tab" data-bs-target="#all">すべて</button>
           </li>
-        <% end %>
-      </ul>
+          <li class="nav-item">
+            <button class="nav-link" data-bs-toggle="tab" data-bs-target="#cookpad" >クックパッド</button>
+          </li>
+          <li class="nav-item">
+            <button class="nav-link" data-bs-toggle="tab" data-bs-target="#delishkitchen">DELISH KITCHEN</button>
+          </li>
+          <li class="nav-item">
+            <button class="nav-link" data-bs-toggle="tab" data-bs-target="#kurashiru">クラシル</button>
+          </li>
+        </ul>
+
+        <div class="tab-content">
+          <!-- すべて -->
+          <div class="tab-pane fade show active" id="all">
+            <ul>
+              <% @recipes.each do |recipe| %>
+                <li class="recipe-item">
+                  <h3><%= link_to recipe[:title], search_show_recipes_path(source_url: recipe[:source_url]) %></h3>
+                  <p><%= "（#{recipe[:site_name]}）" %></p>
+                </li>
+              <% end %>
+            </ul>
+          </div>
+
+          <!-- クックパッド -->
+          <div class="tab-pane fade" id="cookpad">
+            <ul>
+              <% @recipes.select { |recipe| recipe[:site_name] == "Cookpad" }.each do |recipe| %>
+                <li class="recipe-item mb-5">
+                  <h3><%= link_to recipe[:title], search_show_recipes_path(source_url: recipe[:source_url]) %></h3>
+                </li>
+              <% end %>
+            </ul>
+          </div>
+
+          <!-- DELISH KITCHEN -->
+          <div class="tab-pane fade" id="delishkitchen">
+            <ul>
+              <% @recipes.select { |recipe| recipe[:site_name] == "DELISH KITCHEN" }.each do |recipe| %>
+                <li class="recipe-item mb-5">
+                  <h3><%= link_to recipe[:title], search_show_recipes_path(source_url: recipe[:source_url]) %></h3>
+                </li>
+              <% end %>
+            </ul>
+          </div>
+
+          <!-- クラシル -->
+          <div class="tab-pane fade" id="kurashiru">
+            <ul>
+              <% @recipes.select { |recipe| recipe[:site_name] == "クラシル" }.each do |recipe| %>
+                <li class="recipe-item mb-5">
+                  <h3><%= link_to recipe[:title], search_show_recipes_path(source_url: recipe[:source_url]) %></h3>
+                </li>
+              <% end %>
+            </ul>
+          </div>
+        </div>
+      </div>
     <% elsif params[:query].present? %>
       <p>該当するレシピは見つかりませんでした。</p>
     <% end %>

--- a/app/views/recipes/search.html.erb
+++ b/app/views/recipes/search.html.erb
@@ -26,9 +26,8 @@
       <ul>
         <% @recipes.each do |recipe| %>
           <li class="recipe-item">
-            <h3><%= link_to recipe[:title], search_show_recipes_path(url: recipe[:source_url]) %></h3>
+            <h3><%= link_to recipe[:title], search_show_recipes_path(source_url: recipe[:source_url]) %></h3>
             <p><%= "（#{recipe[:site_name]}）" %></p>
-            <%= image_tag recipe[:image_url], alt: recipe[:title], width: 150 if recipe[:image_url].present? %>
           </li>
         <% end %>
       </ul>

--- a/app/views/recipes/search.html.erb
+++ b/app/views/recipes/search.html.erb
@@ -16,7 +16,7 @@
       <div class="text-center">
         <%= label_tag :query, "レシピを検索" %>
         <%= text_field_tag :query, params[:query], placeholder: "例: カレー" %>
-        <%= submit_tag "検索" %>
+        <%= submit_tag "検索", data: { turbo: false } %>
       </div>
     <% end %>
     
@@ -44,7 +44,7 @@
             <ul>
               <% @recipes.each do |recipe| %>
                 <li class="recipe-item">
-                  <h3><%= link_to recipe[:title], search_show_recipes_path(source_url: recipe[:source_url]) %></h3>
+                  <h3><%= link_to recipe[:title], search_show_recipes_path(source_url: recipe[:source_url]), data: { turbo: false } %></h3>
                   <p><%= "（#{recipe[:site_name]}）" %></p>
                 </li>
               <% end %>
@@ -56,7 +56,7 @@
             <ul>
               <% @recipes.select { |recipe| recipe[:site_name] == "Cookpad" }.each do |recipe| %>
                 <li class="recipe-item mb-5">
-                  <h3><%= link_to recipe[:title], search_show_recipes_path(source_url: recipe[:source_url]) %></h3>
+                  <h3><%= link_to recipe[:title], search_show_recipes_path(source_url: recipe[:source_url]), data: { turbo: false } %></h3>
                 </li>
               <% end %>
             </ul>
@@ -67,7 +67,7 @@
             <ul>
               <% @recipes.select { |recipe| recipe[:site_name] == "DELISH KITCHEN" }.each do |recipe| %>
                 <li class="recipe-item mb-5">
-                  <h3><%= link_to recipe[:title], search_show_recipes_path(source_url: recipe[:source_url]) %></h3>
+                  <h3><%= link_to recipe[:title], search_show_recipes_path(source_url: recipe[:source_url]), data: { turbo: false } %></h3>
                 </li>
               <% end %>
             </ul>
@@ -78,7 +78,7 @@
             <ul>
               <% @recipes.select { |recipe| recipe[:site_name] == "クラシル" }.each do |recipe| %>
                 <li class="recipe-item mb-5">
-                  <h3><%= link_to recipe[:title], search_show_recipes_path(source_url: recipe[:source_url]) %></h3>
+                  <h3><%= link_to recipe[:title], search_show_recipes_path(source_url: recipe[:source_url]), data: { turbo: false } %></h3>
                 </li>
               <% end %>
             </ul>

--- a/app/views/recipes/search.html.erb
+++ b/app/views/recipes/search.html.erb
@@ -10,48 +10,30 @@
     </div>
   </div>
   <h1 class="page-title text-center"><%= t('.title') %></h1>
-  <div class="page-container text-center px-3">
-    <div class="row">
-      <div class="col d-flex justify-content-center align-items-center">
-        <%= link_to t('.cookpad'), "https://cookpad.com/", class: 'btn btn-cookpad', target: "_blank" %>
+  <div class="page-container text-start px-3">
+    <!-- 検索フォーム -->
+    <%= form_with url: search_recipes_path, method: :get, local: true do %>
+      <div class="text-center">
+        <%= label_tag :query, "レシピを検索" %>
+        <%= text_field_tag :query, params[:query], placeholder: "例: カレー" %>
+        <%= submit_tag "検索" %>
       </div>
-    </div>
-    <div class="row">
-      <div class="col d-flex justify-content-center align-items-center">
-        <%= link_to t('.delish_kitchen'), "https://delishkitchen.tv/", class: 'btn btn-delish-kitchen', target: "_blank" %>
-      </div>
-    </div>
-    <div class="row">
-      <div class="col d-flex justify-content-center align-items-center">
-        <%= link_to t('.kurashiru'), "https://www.kurashiru.com/", class: 'btn btn-kurashiru', target: "_blank" %>
-      </div>
-    </div>
+    <% end %>
+    
+    <!-- 検索結果表示 -->
+    <% if @recipes.present? %>
+      <h2 class="px-5 pt-5 pb-3">検索結果：</h2>
+      <ul>
+        <% @recipes.each do |recipe| %>
+          <li class="recipe-item">
+            <h3><%= link_to recipe[:title], recipe[:source_url], target: "_blank" %></h3>
+            <p><%= "（#{recipe[:site_name]}）" %></p>
+            <%= image_tag recipe[:image_url], alt: recipe[:title], width: 150 if recipe[:image_url].present? %>
+          </li>
+        <% end %>
+      </ul>
+    <% elsif params[:query].present? %>
+      <p>該当するレシピは見つかりませんでした。</p>
+    <% end %>
   </div>
 </div>
-<h1>レシピ検索</h1>
-
-<!-- 検索フォーム -->
-<%= form_with url: search_recipes_path, method: :get, local: true do %>
-  <div>
-    <%= label_tag :query, "レシピを検索" %>
-    <%= text_field_tag :query, params[:query], placeholder: "例: カレー" %>
-    <%= submit_tag "検索" %>
-  </div>
-<% end %>
-
-<!-- 検索結果表示 -->
-<% if @recipes.present? %>
-  <h2>検索結果:</h2>
-  <ul>
-    <% @recipes.each do |recipe| %>
-      <li>
-        <h3><%= link_to recipe[:title], recipe[:source_url], target: "_blank" %></h3>
-        <p><%= recipe[:site_name] %></p>
-        <%= image_tag recipe[:image_url], alt: recipe[:title], width: 150 if recipe[:image_url].present? %>
-      </li>
-    <% end %>
-  </ul>
-<% elsif params[:query].present? %>
-  <p>該当するレシピは見つかりませんでした。</p>
-<% end %>
-

--- a/app/views/recipes/search_show.html.erb
+++ b/app/views/recipes/search_show.html.erb
@@ -38,9 +38,14 @@
           </div>
         </div>
       </div>
+      <div class="text-center mt-5">
+        <%= button_to 'このレシピを保存する', save_recipe_recipes_path, method: :post, params: { recipe: { source_url: @source_site_url } }, class: "btn btn-primary" %>
+      </div>
 
       <!-- 戻るボタン -->
-      <%= link_to 'もどる', request.referer || root_path, class: "btn btn-primary mt-5" %>
+      <div class="text-center mt-5">
+        <%= link_to 'もどる', request.referer || root_path, class: "btn btn-success" %>
+      </div>
     </div>
   </div>
 </div>

--- a/app/views/recipes/search_show.html.erb
+++ b/app/views/recipes/search_show.html.erb
@@ -1,22 +1,46 @@
-<h1>レシピ詳細</h1>
+<div class="container">
+  <div class="card custom-card-manual-save mx-auto my-5 pb-3">
+    <div class="row d-flex justify-content-end show-recipe-title">
+      <div class="col-12 d-flex justify-content-center">
+        <h1><%= @title %></h1>
+      </div>
+      <div class="col-4 d-flex justify-content-center source-site">
+        <p>出典: <%= link_to @source_site_name, @source_site_url, class: "no-underline", target: "_blank" %></p>
+      </div>
 
-<h1><%= @title %></h1>
+      <div class="container px-3">
+        <div class="row">
+          <div class="col-12">
+            <div class="container px-3">
+              <% if @image_url.present? %>
+                <img src="<%= @image_url %>" alt="<%= @title %>" class="img-fluid">
+              <% end %>
+              <div class="row show-ingredient-row">
+              <div class="col-12">
+                <h2>材料</h2>
+                <ul>
+                  <% @ingredients.each do |ingredient| %>
+                    <li><%= ingredient[:name] %>: <%= ingredient[:quantity] %></li>
+                  <% end %>
+                </ul>
+              </div>
+            </div>
+          </div>
+          <div class="col-12">
+            <div class="container px-3">
+              <div class="col-12">
+                <h2>作り方</h2>
+                <% @steps.each do |step| %>
+                  <p><strong><%= step[:number] %>:</strong> <%= step[:instruction] %><p>
+                <% end %>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
 
-<% if @image_url.present? %>
-  <img src="<%= @image_url %>" alt="<%= @title %>">
-<% end %>
-
-<h2>材料</h2>
-<ul>
-  <% @ingredients.each do |ingredient| %>
-    <li><%= ingredient[:name] %>: <%= ingredient[:quantity] %></li>
-  <% end %>
-</ul>
-
-<h2>作り方</h2>
-<% @steps.each do |step| %>
-  <p><strong><%= step[:number] %>:</strong> <%= step[:instruction] %><p>
-<% end %>
-
-<!-- 戻るボタン -->
-<%= link_to 'もどる', request.referer || root_path, class: 'btn btn-primary' %>
+      <!-- 戻るボタン -->
+      <%= link_to 'もどる', request.referer || root_path, class: "btn btn-primary mt-5" %>
+    </div>
+  </div>
+</div>

--- a/app/views/recipes/search_show.html.erb
+++ b/app/views/recipes/search_show.html.erb
@@ -1,0 +1,22 @@
+<h1>レシピ詳細</h1>
+
+<h1><%= @title %></h1>
+
+<% if @image_url.present? %>
+  <img src="<%= @image_url %>" alt="<%= @title %>">
+<% end %>
+
+<h2>材料</h2>
+<ul>
+  <% @ingredients.each do |ingredient| %>
+    <li><%= ingredient[:name] %>: <%= ingredient[:quantity] %></li>
+  <% end %>
+</ul>
+
+<h2>作り方</h2>
+<% @steps.each do |step| %>
+  <p><strong><%= step[:number] %>:</strong> <%= step[:instruction] %><p>
+<% end %>
+
+<!-- 戻るボタン -->
+<%= link_to 'もどる', request.referer || root_path, class: 'btn btn-primary' %>

--- a/app/views/recipes/search_show.html.erb
+++ b/app/views/recipes/search_show.html.erb
@@ -2,7 +2,7 @@
   <div class="card custom-card-manual-save mx-auto my-5 pb-3">
     <div class="row d-flex justify-content-end show-recipe-title">
       <div class="col-12 d-flex justify-content-center">
-        <h1><%= @title %></h1>
+        <h2><%= @title %></h2>
       </div>
       <div class="col-4 d-flex justify-content-center source-site">
         <p>出典: <%= link_to @source_site_name, @source_site_url, class: "no-underline", target: "_blank" %></p>
@@ -39,12 +39,12 @@
         </div>
       </div>
       <div class="text-center mt-5">
-        <%= button_to 'このレシピを保存する', save_recipe_recipes_path, method: :post, params: { recipe: { source_url: @source_site_url } }, class: "btn btn-primary" %>
+        <%= button_to 'このレシピを保存する', save_recipe_recipes_path, method: :post, params: { recipe: { source_url: @source_site_url } }, class: "btn btn-primary", data: { turbo: false } %>
       </div>
 
       <!-- 戻るボタン -->
       <div class="text-center mt-5">
-        <%= link_to 'もどる', request.referer || root_path, class: "btn btn-success" %>
+        <%= link_to 'もどる', request.referer || root_path, class: "btn btn-success", data: { turbo: false } %>
       </div>
     </div>
   </div>

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -1,6 +1,6 @@
 # /recipes/fetch_recipe のPOSTリクエストに対して、1秒間に1回の制限
 Rack::Attack.throttle('recipes/fetch_recipe', limit: 1, period: 1.seconds) do |req|
-  if req.path == '/recipes/fetch_recipe' && req.post?
+  if req.post? && ['/recipes/fetch_recipe', '/recipes/search', '/recipes/search_show'].include?(req.path)
     req.ip
   end
 end

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -112,6 +112,11 @@ ja:
       title: レシピの自動保存
       enter_the_url: レシピページのURLを入力してください
       fetch_recipe: レシピを保存
+    save_recipe:
+      success: レシピを保存しました
+      failure: レシピの保存に失敗しました
+      update_success: レシピを更新しました
+      failure_success: レシピの更新に失敗しました
     fetch_recipe:
       success: レシピを保存しました
       failure: レシピの保存に失敗しました

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,6 +18,7 @@ Rails.application.routes.draw do
     collection do
       get 'search'  # レシピ検索ページに対応するルート
       get 'search_show'  # 検索したレシピの詳細ページに対応するルート
+      post 'save_recipe'  # 検索したレシピ詳細ページからレシピを保存するルート
       get 'save_options'  # レシピ保存方法選択ページに対応するルート
       get 'auto_save'  # レシピ自動保存ページに対応するルート
       post 'fetch_recipe'  # レシピの自動取得アクション

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,6 +17,7 @@ Rails.application.routes.draw do
   resources :recipes do
     collection do
       get 'search'  # レシピ検索ページに対応するルート
+      get 'search_show'  # 検索したレシピの詳細ページに対応するルート
       get 'save_options'  # レシピ保存方法選択ページに対応するルート
       get 'auto_save'  # レシピ自動保存ページに対応するルート
       post 'fetch_recipe'  # レシピの自動取得アクション


### PR DESCRIPTION
# 概要
レシピ検索ページのアップデート
## 内容
レシピ検索ページについて、以下の機能を追加、削除
- 各レシピサイトへのリンクを削除
- 検索フォームを追加
- 検索フォームにキーワードを入力することで、「クックパッド」「DELISH KITCHEN」「クラシル」から同時に検索し、検索結果（レシピタイトルとレシピのソースサイト名）を表示
- 検索後、表示されているレシピタイトルをクリックすることで、レシピ詳細を確認可能（レシピ詳細画面を別途作成）
- レシピ詳細画面から、該当レシピを保存可能

その他
- 修正したページのレスポンシブ化
- rack_attackのエンドポイント追加（'/recipes/search', '/recipes/search_show'）
- レシピの自動保存ページ（URL入力ページ）に各レシピサイトへのリンクを追加